### PR TITLE
Generated code changes as a result of UNR-160 fix

### DIFF
--- a/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_Character.cpp
+++ b/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_Character.cpp
@@ -441,13 +441,13 @@ void USpatialTypeBinding_Character::ServerSendUpdate_MultiClient(const uint8* RE
 		}
 		case 6: // field_replicatedmovement
 		{
-			FRepMovement Value = *(reinterpret_cast<FRepMovement const*>(Data));
+			const FRepMovement& Value = *(reinterpret_cast<FRepMovement const*>(Data));
 
 			{
 				TArray<uint8> ValueData;
 				FMemoryWriter ValueDataWriter(ValueData);
 				bool Success;
-				Value.NetSerialize(ValueDataWriter, PackageMap, Success);
+				(const_cast<FRepMovement&>(Value)).NetSerialize(ValueDataWriter, PackageMap, Success);
 				OutUpdate.set_field_replicatedmovement(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 			}
 			break;
@@ -477,21 +477,21 @@ void USpatialTypeBinding_Character::ServerSendUpdate_MultiClient(const uint8* RE
 		}
 		case 8: // field_attachmentreplication_locationoffset
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_locationoffset(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 9: // field_attachmentreplication_relativescale3d
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_relativescale3d(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 10: // field_attachmentreplication_rotationoffset
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_rotationoffset(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;
@@ -664,14 +664,14 @@ void USpatialTypeBinding_Character::ServerSendUpdate_MultiClient(const uint8* RE
 		}
 		case 21: // field_replicatedbasedmovement_location
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_replicatedbasedmovement_location(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 22: // field_replicatedbasedmovement_rotation
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_replicatedbasedmovement_rotation(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;
@@ -778,14 +778,14 @@ void USpatialTypeBinding_Character::ServerSendUpdate_MultiClient(const uint8* RE
 		}
 		case 35: // field_reprootmotion_location
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_reprootmotion_location(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 36: // field_reprootmotion_rotation
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_reprootmotion_rotation(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;
@@ -836,27 +836,27 @@ void USpatialTypeBinding_Character::ServerSendUpdate_MultiClient(const uint8* RE
 		}
 		case 41: // field_reprootmotion_authoritativerootmotion
 		{
-			FRootMotionSourceGroup Value = *(reinterpret_cast<FRootMotionSourceGroup const*>(Data));
+			const FRootMotionSourceGroup& Value = *(reinterpret_cast<FRootMotionSourceGroup const*>(Data));
 
 			{
 				TArray<uint8> ValueData;
 				FMemoryWriter ValueDataWriter(ValueData);
 				bool Success;
-				Value.NetSerialize(ValueDataWriter, PackageMap, Success);
+				(const_cast<FRootMotionSourceGroup&>(Value)).NetSerialize(ValueDataWriter, PackageMap, Success);
 				OutUpdate.set_field_reprootmotion_authoritativerootmotion(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 			}
 			break;
 		}
 		case 42: // field_reprootmotion_acceleration
 		{
-			FVector_NetQuantize10 Value = *(reinterpret_cast<FVector_NetQuantize10 const*>(Data));
+			const FVector_NetQuantize10& Value = *(reinterpret_cast<FVector_NetQuantize10 const*>(Data));
 
 			OutUpdate.set_field_reprootmotion_acceleration(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 43: // field_reprootmotion_linearvelocity
 		{
-			FVector_NetQuantize10 Value = *(reinterpret_cast<FVector_NetQuantize10 const*>(Data));
+			const FVector_NetQuantize10& Value = *(reinterpret_cast<FVector_NetQuantize10 const*>(Data));
 
 			OutUpdate.set_field_reprootmotion_linearvelocity(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;

--- a/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_PlayerController.cpp
+++ b/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_PlayerController.cpp
@@ -550,14 +550,14 @@ void USpatialTypeBinding_PlayerController::ServerSendUpdate_SingleClient(const u
 	{
 		case 18: // field_targetviewrotation
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_targetviewrotation(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;
 		}
 		case 19: // field_spawnlocation
 		{
-			FVector Value = *(reinterpret_cast<FVector const*>(Data));
+			const FVector& Value = *(reinterpret_cast<FVector const*>(Data));
 
 			OutUpdate.set_field_spawnlocation(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
@@ -609,13 +609,13 @@ void USpatialTypeBinding_PlayerController::ServerSendUpdate_MultiClient(const ui
 		}
 		case 6: // field_replicatedmovement
 		{
-			FRepMovement Value = *(reinterpret_cast<FRepMovement const*>(Data));
+			const FRepMovement& Value = *(reinterpret_cast<FRepMovement const*>(Data));
 
 			{
 				TArray<uint8> ValueData;
 				FMemoryWriter ValueDataWriter(ValueData);
 				bool Success;
-				Value.NetSerialize(ValueDataWriter, PackageMap, Success);
+				(const_cast<FRepMovement&>(Value)).NetSerialize(ValueDataWriter, PackageMap, Success);
 				OutUpdate.set_field_replicatedmovement(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 			}
 			break;
@@ -645,21 +645,21 @@ void USpatialTypeBinding_PlayerController::ServerSendUpdate_MultiClient(const ui
 		}
 		case 8: // field_attachmentreplication_locationoffset
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_locationoffset(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 9: // field_attachmentreplication_relativescale3d
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_relativescale3d(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 10: // field_attachmentreplication_rotationoffset
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_rotationoffset(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;
@@ -1772,7 +1772,7 @@ void USpatialTypeBinding_PlayerController::ClientUnmutePlayer_SendCommand(worker
 			TArray<uint8> ValueData;
 			FMemoryWriter ValueDataWriter(ValueData);
 			bool Success;
-			PlayerId.NetSerialize(ValueDataWriter, PackageMap, Success);
+			(const_cast<FUniqueNetIdRepl&>(PlayerId)).NetSerialize(ValueDataWriter, PackageMap, Success);
 			Request.set_field_playerid(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 		}
 
@@ -3070,7 +3070,7 @@ void USpatialTypeBinding_PlayerController::ClientMutePlayer_SendCommand(worker::
 			TArray<uint8> ValueData;
 			FMemoryWriter ValueDataWriter(ValueData);
 			bool Success;
-			PlayerId.NetSerialize(ValueDataWriter, PackageMap, Success);
+			(const_cast<FUniqueNetIdRepl&>(PlayerId)).NetSerialize(ValueDataWriter, PackageMap, Success);
 			Request.set_field_playerid(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 		}
 
@@ -3822,7 +3822,7 @@ void USpatialTypeBinding_PlayerController::ServerUnmutePlayer_SendCommand(worker
 			TArray<uint8> ValueData;
 			FMemoryWriter ValueDataWriter(ValueData);
 			bool Success;
-			PlayerId.NetSerialize(ValueDataWriter, PackageMap, Success);
+			(const_cast<FUniqueNetIdRepl&>(PlayerId)).NetSerialize(ValueDataWriter, PackageMap, Success);
 			Request.set_field_playerid(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 		}
 
@@ -4062,7 +4062,7 @@ void USpatialTypeBinding_PlayerController::ServerMutePlayer_SendCommand(worker::
 			TArray<uint8> ValueData;
 			FMemoryWriter ValueDataWriter(ValueData);
 			bool Success;
-			PlayerId.NetSerialize(ValueDataWriter, PackageMap, Success);
+			(const_cast<FUniqueNetIdRepl&>(PlayerId)).NetSerialize(ValueDataWriter, PackageMap, Success);
 			Request.set_field_playerid(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 		}
 

--- a/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_PlayerState.cpp
+++ b/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_PlayerState.cpp
@@ -368,13 +368,13 @@ void USpatialTypeBinding_PlayerState::ServerSendUpdate_MultiClient(const uint8* 
 		}
 		case 6: // field_replicatedmovement
 		{
-			FRepMovement Value = *(reinterpret_cast<FRepMovement const*>(Data));
+			const FRepMovement& Value = *(reinterpret_cast<FRepMovement const*>(Data));
 
 			{
 				TArray<uint8> ValueData;
 				FMemoryWriter ValueDataWriter(ValueData);
 				bool Success;
-				Value.NetSerialize(ValueDataWriter, PackageMap, Success);
+				(const_cast<FRepMovement&>(Value)).NetSerialize(ValueDataWriter, PackageMap, Success);
 				OutUpdate.set_field_replicatedmovement(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 			}
 			break;
@@ -404,21 +404,21 @@ void USpatialTypeBinding_PlayerState::ServerSendUpdate_MultiClient(const uint8* 
 		}
 		case 8: // field_attachmentreplication_locationoffset
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_locationoffset(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 9: // field_attachmentreplication_relativescale3d
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_relativescale3d(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 10: // field_attachmentreplication_rotationoffset
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_rotationoffset(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;
@@ -571,13 +571,13 @@ void USpatialTypeBinding_PlayerState::ServerSendUpdate_MultiClient(const uint8* 
 		}
 		case 25: // field_uniqueid
 		{
-			FUniqueNetIdRepl Value = *(reinterpret_cast<FUniqueNetIdRepl const*>(Data));
+			const FUniqueNetIdRepl& Value = *(reinterpret_cast<FUniqueNetIdRepl const*>(Data));
 
 			{
 				TArray<uint8> ValueData;
 				FMemoryWriter ValueDataWriter(ValueData);
 				bool Success;
-				Value.NetSerialize(ValueDataWriter, PackageMap, Success);
+				(const_cast<FUniqueNetIdRepl&>(Value)).NetSerialize(ValueDataWriter, PackageMap, Success);
 				OutUpdate.set_field_uniqueid(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 			}
 			break;

--- a/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_WheeledVehicle.cpp
+++ b/workers/unreal/Game/Source/SampleGame/Generated/SpatialTypeBinding_WheeledVehicle.cpp
@@ -367,13 +367,13 @@ void USpatialTypeBinding_WheeledVehicle::ServerSendUpdate_MultiClient(const uint
 		}
 		case 6: // field_replicatedmovement
 		{
-			FRepMovement Value = *(reinterpret_cast<FRepMovement const*>(Data));
+			const FRepMovement& Value = *(reinterpret_cast<FRepMovement const*>(Data));
 
 			{
 				TArray<uint8> ValueData;
 				FMemoryWriter ValueDataWriter(ValueData);
 				bool Success;
-				Value.NetSerialize(ValueDataWriter, PackageMap, Success);
+				(const_cast<FRepMovement&>(Value)).NetSerialize(ValueDataWriter, PackageMap, Success);
 				OutUpdate.set_field_replicatedmovement(std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
 			}
 			break;
@@ -403,21 +403,21 @@ void USpatialTypeBinding_WheeledVehicle::ServerSendUpdate_MultiClient(const uint
 		}
 		case 8: // field_attachmentreplication_locationoffset
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_locationoffset(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 9: // field_attachmentreplication_relativescale3d
 		{
-			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_relativescale3d(improbable::Vector3f(Value.X, Value.Y, Value.Z));
 			break;
 		}
 		case 10: // field_attachmentreplication_rotationoffset
 		{
-			FRotator Value = *(reinterpret_cast<FRotator const*>(Data));
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
 
 			OutUpdate.set_field_attachmentreplication_rotationoffset(improbable::unreal::UnrealFRotator(Value.Yaw, Value.Pitch, Value.Roll));
 			break;


### PR DESCRIPTION
The codegen change here: https://github.com/improbable/unreal-gdk/pull/80

Even though it fixes the compilation error for arrays of structs, they still cause problems at runtime when doing the initial replication (UNR-164).
So since we don't have replicated arrays in the classes we generate TypeBindings for, that change isn't reflected in this PR.