### PR TITLE
Removing git clean -xfd

### DIFF
--- a/clean_gdk_symlink.bat
+++ b/clean_gdk_symlink.bat
@@ -14,10 +14,6 @@ CALL :clean_path %SPATIALGDK_BINARIESPATH%
 CALL :clean_path %SPATIALGDK_SCHEMAPATH%
 ECHO Finished cleaning up old symlinks
 
-ECHO Performing git clean
-git clean -xdf
-ECHO Finished git clean
-
 EXIT /B 0
 
 :clean_path


### PR DESCRIPTION
It's seriously misleading that this thing runs git clean -xfd which is like dropping a nuke on a repo. 
It's up to devs to decide when it's appropriate to nuke their own work and changes, the unreal-gdk should have nothing to do with this.