### PR TITLE
Feature/unr 276 enable linux builds

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -43,7 +43,7 @@ markStartOfBlock "Build the SampleGame"
     exit 1
   fi
 
-  Game/Scripts/Build.bat "SampleGameServer" "Linux" "Development" "Game/SampleGame.uproject" --skip-codegen
+  Game/Scripts/Build.bat "SampleGameServer" "Linux" "Development" "SampleGame.uproject" --skip-codegen
   if [[ ! -f "spatial/build/assembly/worker/UnrealWorker@Linux.zip" ]]; then
     echo "Linux Server was not properly built."
     exit 1

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -43,12 +43,11 @@ markStartOfBlock "Build the SampleGame"
     exit 1
   fi
 
-  # UNR-276 - This is disabled until TC agents have UE4.19 properly configured.
-  # Game/Scripts/Build.bat "SampleGameServer" "Linux" "Development" "Game/SampleGame.uproject" --skip-codegen
-  # if [[ ! -f "spatial/build/assembly/worker/UnrealWorker@Linux.zip" ]]; then
-  #   echo "Linux Server was not properly built."
-  #   exit 1
-  # fi
+  Game/Scripts/Build.bat "SampleGameServer" "Linux" "Development" "Game/SampleGame.uproject" --skip-codegen
+  if [[ ! -f "spatial/build/assembly/worker/UnrealWorker@Linux.zip" ]]; then
+    echo "Linux Server was not properly built."
+    exit 1
+  fi
 
   Game/Scripts/Build.bat "SampleGame" "Win64" "Development" "SampleGame.uproject" --skip-codegen
   if [[ ! -f "spatial/build/assembly/worker/UnrealClient@Windows.zip" ]]; then

--- a/ci/pinned-tools.sh
+++ b/ci/pinned-tools.sh
@@ -33,7 +33,7 @@ function getPlatformName() {
 
 # The current version of Unreal.
 if [ -z "${UNREAL_HOME+x}" ]; then
-  UNREAL_VERSION="419-SpatialGDK"
+  UNREAL_VERSION="4.19-GDK-51ab03656b3"
   export UNREAL_HOME="C:/Unreal/UnrealEngine-${UNREAL_VERSION}"
 fi
 


### PR DESCRIPTION
Re-enabled linux server builds in CI.
Updated pinned tools to point to newly deployed UE_GDK build.

Primary reviewer:
@danielimprobable 