### PR TITLE
[UNR-440] Set Spatial project to 'unreal_gdk' and upgrade Spatial to 13.1.1

### DIFF
--- a/spatial/spatialos.json
+++ b/spatial/spatialos.json
@@ -1,11 +1,11 @@
 {
-  "name": "demo",
+  "name": "unreal_gdk",
   "project_version": "0.0.1",
-  "sdk_version": "13.0.0",
+  "sdk_version": "13.1.1",
   "dependencies": [
     {
       "name": "standard_library",
-      "version": "13.0.0"
+      "version": "13.1.1"
     }
   ]
 }


### PR DESCRIPTION
Context on why call the project `unreal_gdk`:
https://improbableio.atlassian.net/browse/UNR-440