### PR TITLE
Added subobject test to testing framework

### DIFF
--- a/Game/Config/DefaultEditorSpatialGDK.ini
+++ b/Game/Config/DefaultEditorSpatialGDK.ini
@@ -57,3 +57,7 @@ TestFNameReplication=Tests/TestFNameReplication.h
 TestMulticastRPC=Tests/TestMulticastRPC.h
 
 TestActor=Tests/TestTArrayReplication.h
+
+TestStaticComponentReplication=Tests/TestStaticComponentReplication.h
+TestComponent=Tests/TestStaticComponentReplication.h
+

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.cpp
@@ -1,0 +1,480 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+
+#include "SpatialTypeBinding_TestComponent.h"
+
+#include "GameFramework/PlayerState.h"
+#include "NetworkGuid.h"
+
+#include "SpatialOS.h"
+#include "EntityBuilder.h"
+
+#include "SpatialConstants.h"
+#include "SpatialConditionMapFilter.h"
+#include "SpatialUnrealObjectRef.h"
+#include "SpatialActorChannel.h"
+#include "SpatialPackageMapClient.h"
+#include "SpatialMemoryReader.h"
+#include "SpatialMemoryWriter.h"
+#include "SpatialNetDriver.h"
+#include "SpatialInterop.h"
+#include "Tests/TestStaticComponentReplication.h"
+
+#include "TestComponentSingleClientRepDataAddComponentOp.h"
+#include "TestComponentMultiClientRepDataAddComponentOp.h"
+#include "TestComponentHandoverDataAddComponentOp.h"
+
+const FRepHandlePropertyMap& USpatialTypeBinding_TestComponent::GetRepHandlePropertyMap() const
+{
+	return RepHandleToPropertyMap;
+}
+
+const FHandoverHandlePropertyMap& USpatialTypeBinding_TestComponent::GetHandoverHandlePropertyMap() const
+{
+	return HandoverHandleToPropertyMap;
+}
+
+UClass* USpatialTypeBinding_TestComponent::GetBoundClass() const
+{
+	return UTestComponent::StaticClass();
+}
+
+void USpatialTypeBinding_TestComponent::Init(USpatialInterop* InInterop, USpatialPackageMapClient* InPackageMap)
+{
+	Super::Init(InInterop, InPackageMap);
+
+
+	UClass* Class = FindObject<UClass>(ANY_PACKAGE, TEXT("TestComponent"));
+
+	// Populate RepHandleToPropertyMap.
+	RepHandleToPropertyMap.Add(1, FRepHandleData(Class, {"bReplicates"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(2, FRepHandleData(Class, {"bIsActive"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(3, FRepHandleData(Class, {"TestProperty"}, {0}, COND_None, REPNOTIFY_OnChanged));
+
+	bIsSingleton = false;
+}
+
+void USpatialTypeBinding_TestComponent::BindToView(bool bIsClient)
+{
+	TSharedPtr<worker::View> View = Interop->GetSpatialOS()->GetView().Pin();
+	ViewCallbacks.Init(View);
+
+	if (Interop->GetNetDriver()->GetNetMode() == NM_Client)
+	{
+		ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData>([this](
+			const worker::ComponentUpdateOp<improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData>& Op)
+		{
+			// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+			if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::ComponentId))
+			{
+				return;
+			}
+			USpatialActorChannel* ActorChannel = Interop->GetActorChannelByEntityId(Op.EntityId);
+			check(ActorChannel);
+			ReceiveUpdate_SingleClient(ActorChannel, Op.Update);
+		}));
+		ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData>([this](
+			const worker::ComponentUpdateOp<improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData>& Op)
+		{
+			// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+			if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::ComponentId))
+			{
+				return;
+			}
+			USpatialActorChannel* ActorChannel = Interop->GetActorChannelByEntityId(Op.EntityId);
+			check(ActorChannel);
+			ReceiveUpdate_MultiClient(ActorChannel, Op.Update);
+		}));
+		if (!bIsClient)
+		{
+			ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentHandoverData>([this](
+				const worker::ComponentUpdateOp<improbable::unreal::generated::testcomponent::TestComponentHandoverData>& Op)
+			{
+				// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+				if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::testcomponent::TestComponentHandoverData::ComponentId))
+				{
+					return;
+				}
+				USpatialActorChannel* ActorChannel = Interop->GetActorChannelByEntityId(Op.EntityId);
+				check(ActorChannel);
+				ReceiveUpdate_Handover(ActorChannel, Op.Update);
+			}));
+		}
+	}
+	ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs>([this](
+		const worker::ComponentUpdateOp<improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs>& Op)
+	{
+		// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+		if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs::ComponentId))
+		{
+			return;
+		}
+		ReceiveUpdate_NetMulticastRPCs(Op.EntityId, Op.Update);
+	}));
+}
+
+void USpatialTypeBinding_TestComponent::UnbindFromView()
+{
+	ViewCallbacks.Reset();
+}
+
+worker::Entity USpatialTypeBinding_TestComponent::CreateActorEntity(const FString& ClientWorkerId, const FVector& Position, const FString& Metadata, const FPropertyChangeState& InitialChanges, USpatialActorChannel* Channel) const
+{
+	// Validate replication list.
+	const uint16 RepHandlePropertyMapCount = GetRepHandlePropertyMap().Num();
+	for (auto& Rep : InitialChanges.RepChanged)
+	{
+		checkf(Rep <= RepHandlePropertyMapCount, TEXT("Attempting to replicate a property with a handle that the type binding is not aware of. Have additional replicated properties been added in a non generated child object?"))
+	}
+
+	// Setup initial data.
+
+	improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Data SingleClientTestComponentData;
+	improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update SingleClientTestComponentUpdate;
+	bool bSingleClientTestComponentUpdateChanged = false;
+	improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Data MultiClientTestComponentData;
+	improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update MultiClientTestComponentUpdate;
+	bool bMultiClientTestComponentUpdateChanged = false;
+	improbable::unreal::generated::testcomponent::TestComponentHandoverData::Data TestComponentHandoverData;
+	improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update TestComponentHandoverDataUpdate;
+	bool bTestComponentHandoverDataUpdateChanged = false;
+
+	FPropertyChangeState TestComponentChangeState = Channel->CreateSubobjectChangeState(Channel->Actor->FindComponentByClass<UTestComponent>());
+	USpatialTypeBinding_TestComponent* TestComponentTypeBinding = Cast<USpatialTypeBinding_TestComponent>(Interop->GetTypeBindingByClass(UTestComponent::StaticClass()));
+	TestComponentTypeBinding->BuildSpatialComponentUpdate(TestComponentChangeState, Channel, SingleClientTestComponentUpdate, bSingleClientTestComponentUpdateChanged, MultiClientTestComponentUpdate, bMultiClientTestComponentUpdateChanged, TestComponentHandoverDataUpdate, bTestComponentHandoverDataUpdateChanged);
+	SingleClientTestComponentUpdate.ApplyTo(SingleClientTestComponentData);
+	MultiClientTestComponentUpdate.ApplyTo(MultiClientTestComponentData);
+	TestComponentHandoverDataUpdate.ApplyTo(TestComponentHandoverData);
+
+	// Create entity.
+	std::string ClientWorkerIdString = TCHAR_TO_UTF8(*ClientWorkerId);
+
+	improbable::WorkerAttributeSet WorkerAttribute{{worker::List<std::string>{"UnrealWorker"}}};
+	improbable::WorkerAttributeSet ClientAttribute{{worker::List<std::string>{"UnrealClient"}}};
+	improbable::WorkerAttributeSet OwningClientAttribute{{"workerId:" + ClientWorkerIdString}};
+
+	improbable::WorkerRequirementSet WorkersOnly{{WorkerAttribute}};
+	improbable::WorkerRequirementSet ClientsOnly{{ClientAttribute}};
+	improbable::WorkerRequirementSet OwningClientOnly{{OwningClientAttribute}};
+	improbable::WorkerRequirementSet AnyUnrealWorkerOrClient{{WorkerAttribute, ClientAttribute}};
+	improbable::WorkerRequirementSet AnyUnrealWorkerOrOwningClient{{WorkerAttribute, OwningClientAttribute}};
+
+	// Set up unreal metadata.
+	improbable::unreal::UnrealMetadata::Data UnrealMetadata;
+	if (Channel->Actor->IsFullNameStableForNetworking())
+	{
+		UnrealMetadata.set_static_path({std::string{TCHAR_TO_UTF8(*Channel->Actor->GetPathName(Channel->Actor->GetWorld()))}});
+	}
+	if (!ClientWorkerIdString.empty())
+	{
+		UnrealMetadata.set_owner_worker_id({ClientWorkerIdString});
+	}
+
+	uint32 CurrentOffset = 1;
+	worker::Map<std::string, std::uint32_t> SubobjectNameToOffset;
+	ForEachObjectWithOuter(Channel->Actor, [&UnrealMetadata, &CurrentOffset, &SubobjectNameToOffset](UObject* Object)
+	{
+		// Objects can only be allocated NetGUIDs if this is true.
+		if (Object->IsSupportedForNetworking() && !Object->IsPendingKill() && !Object->IsEditorOnly())
+		{
+			SubobjectNameToOffset.emplace(TCHAR_TO_UTF8(*(Object->GetName())), CurrentOffset);
+			CurrentOffset++;
+		}
+	});
+	UnrealMetadata.set_subobject_name_to_offset(SubobjectNameToOffset);
+
+	// Build entity.
+	const improbable::Coordinates SpatialPosition = SpatialConstants::LocationToSpatialOSCoordinates(Position);
+	return improbable::unreal::FEntityBuilder::Begin()
+		.AddPositionComponent(improbable::Position::Data{SpatialPosition}, WorkersOnly)
+		.AddMetadataComponent(improbable::Metadata::Data{TCHAR_TO_UTF8(*Metadata)})
+		.SetPersistence(true)
+		.SetReadAcl(AnyUnrealWorkerOrClient)
+		.AddComponent<improbable::unreal::UnrealMetadata>(UnrealMetadata, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData>(SingleClientTestComponentData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData>(MultiClientTestComponentData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentHandoverData>(TestComponentHandoverData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentClientRPCs>(improbable::unreal::generated::testcomponent::TestComponentClientRPCs::Data{}, OwningClientOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentServerRPCs>(improbable::unreal::generated::testcomponent::TestComponentServerRPCs::Data{}, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs>(improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs::Data{}, WorkersOnly)
+		.Build();
+}
+
+void USpatialTypeBinding_TestComponent::SendComponentUpdates(const FPropertyChangeState& Changes, USpatialActorChannel* Channel, const FEntityId& EntityId) const
+{
+	// Build SpatialOS updates.
+	improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update SingleClientUpdate;
+	bool bSingleClientUpdateChanged = false;
+	improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update MultiClientUpdate;
+	bool bMultiClientUpdateChanged = false;
+	improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update HandoverDataUpdate;
+	bool bHandoverDataUpdateChanged = false;
+	BuildSpatialComponentUpdate(Changes, Channel, SingleClientUpdate, bSingleClientUpdateChanged, MultiClientUpdate, bMultiClientUpdateChanged, HandoverDataUpdate, bHandoverDataUpdateChanged);
+
+	// Send SpatialOS updates if anything changed.
+	TSharedPtr<worker::Connection> Connection = Interop->GetSpatialOS()->GetConnection().Pin();
+	if (bSingleClientUpdateChanged)
+	{
+		Connection->SendComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData>(EntityId.ToSpatialEntityId(), SingleClientUpdate);
+	}
+	if (bMultiClientUpdateChanged)
+	{
+		Connection->SendComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData>(EntityId.ToSpatialEntityId(), MultiClientUpdate);
+	}
+	if (bHandoverDataUpdateChanged)
+	{
+		Connection->SendComponentUpdate<improbable::unreal::generated::testcomponent::TestComponentHandoverData>(EntityId.ToSpatialEntityId(), HandoverDataUpdate);
+	}
+}
+
+void USpatialTypeBinding_TestComponent::SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters)
+{
+	TSharedPtr<worker::Connection> Connection = Interop->GetSpatialOS()->GetConnection().Pin();
+	auto SenderFuncIterator = RPCToSenderMap.Find(Function->GetFName());
+	if (SenderFuncIterator == nullptr)
+	{
+		UE_LOG(LogSpatialGDKInterop, Error, TEXT("Sender for %s has not been registered with RPCToSenderMap."), *Function->GetFName().ToString());
+		return;
+	}
+	checkf(*SenderFuncIterator, TEXT("Sender for %s has been registered as null."), *Function->GetFName().ToString());
+	(this->*(*SenderFuncIterator))(Connection.Get(), Parameters, TargetObject);
+}
+
+void USpatialTypeBinding_TestComponent::ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const
+{
+	auto* SingleClientAddOp = Cast<UTestComponentSingleClientRepDataAddComponentOp>(AddComponentOp);
+	if (SingleClientAddOp)
+	{
+		auto Update = improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update::FromInitialData(*SingleClientAddOp->Data.data());
+		ReceiveUpdate_SingleClient(Channel, Update);
+		return;
+	}
+	auto* MultiClientAddOp = Cast<UTestComponentMultiClientRepDataAddComponentOp>(AddComponentOp);
+	if (MultiClientAddOp)
+	{
+		auto Update = improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update::FromInitialData(*MultiClientAddOp->Data.data());
+		ReceiveUpdate_MultiClient(Channel, Update);
+		return;
+	}
+	auto* HandoverDataAddOp = Cast<UTestComponentHandoverDataAddComponentOp>(AddComponentOp);
+	if (HandoverDataAddOp)
+	{
+		auto Update = improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update::FromInitialData(*HandoverDataAddOp->Data.data());
+		ReceiveUpdate_Handover(Channel, Update);
+		return;
+	}
+}
+
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestComponent::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+{
+	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
+	if (bIsClient)
+	{
+		if (!bAutonomousProxy)
+		{
+			Interest.emplace(improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::ComponentId, worker::InterestOverride{false});
+		}
+		Interest.emplace(improbable::unreal::generated::testcomponent::TestComponentHandoverData::ComponentId, worker::InterestOverride{false});
+	}
+	return Interest;
+}
+
+void USpatialTypeBinding_TestComponent::BuildSpatialComponentUpdate(
+	const FPropertyChangeState& Changes,
+	USpatialActorChannel* Channel,
+	improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update& SingleClientUpdate,
+	bool& bSingleClientUpdateChanged,
+	improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update& MultiClientUpdate,
+	bool& bMultiClientUpdateChanged,
+	improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update& HandoverDataUpdate,
+	bool& bHandoverDataUpdateChanged) const
+{
+	const FRepHandlePropertyMap& RepPropertyMap = GetRepHandlePropertyMap();
+	const FHandoverHandlePropertyMap& HandoverPropertyMap = GetHandoverHandlePropertyMap();
+	if (Changes.RepChanged.Num() > 0)
+	{
+		// Populate the replicated data component updates from the replicated property changelist.
+		FChangelistIterator ChangelistIterator(Changes.RepChanged, 0);
+		FRepHandleIterator HandleIterator(ChangelistIterator, Changes.RepCmds, Changes.RepBaseHandleToCmdIndex, 0, 1, 0, Changes.RepCmds.Num() - 1);
+		while (HandleIterator.NextHandle())
+		{
+			const FRepLayoutCmd& Cmd = Changes.RepCmds[HandleIterator.CmdIndex];
+			const FRepHandleData& PropertyMapData = RepPropertyMap[HandleIterator.Handle];
+			const uint8* Data = PropertyMapData.GetPropertyData(Changes.SourceData) + HandleIterator.ArrayOffset;
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Sending property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*Channel->Actor->GetName(),
+				Channel->GetEntityId().ToSpatialEntityId(),
+				*Cmd.Property->GetName(),
+				HandleIterator.Handle);
+			switch (GetGroupFromCondition(PropertyMapData.Condition))
+			{
+			case GROUP_SingleClient:
+				ServerSendUpdate_SingleClient(Data, HandleIterator.Handle, Cmd.Property, Channel, SingleClientUpdate);
+				bSingleClientUpdateChanged = true;
+				break;
+			case GROUP_MultiClient:
+				ServerSendUpdate_MultiClient(Data, HandleIterator.Handle, Cmd.Property, Channel, MultiClientUpdate);
+				bMultiClientUpdateChanged = true;
+				break;
+			}
+			if (Cmd.Type == REPCMD_DynamicArray)
+			{
+				if (!HandleIterator.JumpOverArray())
+				{
+					break;
+				}
+			}
+		}
+	}
+
+	// Populate the handover data component update from the handover property changelist.
+	for (uint16 ChangedHandle : Changes.HandoverChanged)
+	{
+		const FHandoverHandleData& PropertyMapData = HandoverPropertyMap[ChangedHandle];
+		const uint8* Data = PropertyMapData.GetPropertyData(Changes.SourceData);
+		UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Sending handover property update. actor %s (%lld), property %s (handle %d)"),
+			*Interop->GetSpatialOS()->GetWorkerId(),
+			*Channel->Actor->GetName(),
+			Channel->GetEntityId().ToSpatialEntityId(),
+			*PropertyMapData.Property->GetName(),
+			ChangedHandle);
+		ServerSendUpdate_Handover(Data, ChangedHandle, PropertyMapData.Property, Channel, HandoverDataUpdate);
+		bHandoverDataUpdateChanged = true;
+	}
+}
+
+void USpatialTypeBinding_TestComponent::ServerSendUpdate_SingleClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update& OutUpdate) const
+{
+}
+
+void USpatialTypeBinding_TestComponent::ServerSendUpdate_MultiClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update& OutUpdate) const
+{
+	switch (Handle)
+	{
+		case 1: // field_breplicates0
+		{
+			bool Value = static_cast<UBoolProperty*>(Property)->GetPropertyValue(Data);
+
+			OutUpdate.set_field_breplicates0(Value);
+			break;
+		}
+		case 2: // field_bisactive0
+		{
+			bool Value = static_cast<UBoolProperty*>(Property)->GetPropertyValue(Data);
+
+			OutUpdate.set_field_bisactive0(Value);
+			break;
+		}
+		case 3: // field_testproperty0
+		{
+			float Value = *(reinterpret_cast<float const*>(Data));
+
+			OutUpdate.set_field_testproperty0(Value);
+			break;
+		}
+	default:
+		checkf(false, TEXT("Unknown replication handle %d encountered when creating a SpatialOS update."));
+		break;
+	}
+}
+
+void USpatialTypeBinding_TestComponent::ServerSendUpdate_Handover(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update& OutUpdate) const
+{
+}
+
+void USpatialTypeBinding_TestComponent::ReceiveUpdate_SingleClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update& Update) const
+{
+	UActorComponent* TargetObject = ActorChannel->Actor->FindComponentByClass<UTestComponent>();
+	ActorChannel->PreReceiveSpatialUpdate(TargetObject);
+	TArray<UProperty*> RepNotifies;
+	ActorChannel->PostReceiveSpatialUpdate(TargetObject, RepNotifies);
+}
+
+void USpatialTypeBinding_TestComponent::ReceiveUpdate_MultiClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update& Update) const
+{
+	UActorComponent* TargetObject = ActorChannel->Actor->FindComponentByClass<UTestComponent>();
+	ActorChannel->PreReceiveSpatialUpdate(TargetObject);
+	TSet<UProperty*> RepNotifies;
+
+	const bool bIsServer = Interop->GetNetDriver()->IsServer();
+	const bool bAutonomousProxy = ActorChannel->IsClientAutonomousProxy(improbable::unreal::generated::testcomponent::TestComponentClientRPCs::ComponentId);
+	const FRepHandlePropertyMap& HandleToPropertyMap = GetRepHandlePropertyMap();
+	FSpatialConditionMapFilter ConditionMap(ActorChannel, bAutonomousProxy);
+
+	if (!Update.field_breplicates0().empty())
+	{
+		// field_breplicates0
+		uint16 Handle = 1;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			bool Value = static_cast<UBoolProperty*>(RepData->Property)->GetPropertyValue(PropertyData);
+
+			Value = (*Update.field_breplicates0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_bisactive0().empty())
+	{
+		// field_bisactive0
+		uint16 Handle = 2;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			bool Value = static_cast<UBoolProperty*>(RepData->Property)->GetPropertyValue(PropertyData);
+
+			Value = (*Update.field_bisactive0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_testproperty0().empty())
+	{
+		// field_testproperty0
+		uint16 Handle = 3;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			float Value = *(reinterpret_cast<float const*>(PropertyData));
+
+			Value = (*Update.field_testproperty0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	ActorChannel->PostReceiveSpatialUpdate(TargetObject, RepNotifies.Array());
+}
+
+void USpatialTypeBinding_TestComponent::ReceiveUpdate_Handover(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update& Update) const
+{
+}
+
+void USpatialTypeBinding_TestComponent::ReceiveUpdate_NetMulticastRPCs(worker::EntityId EntityId, const improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs::Update& Update)
+{
+}

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.h
@@ -1,0 +1,69 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+#pragma once
+
+#include "CoreMinimal.h"
+#include <improbable/worker.h>
+#include <improbable/view.h>
+#include <improbable/unreal/gdk/core_types.h>
+#include <improbable/unreal/gdk/unreal_metadata.h>
+#include <improbable/unreal/generated/UnrealTestComponent.h>
+#include "ScopedViewCallbacks.h"
+#include "SpatialTypeBinding.h"
+#include "SpatialTypeBinding_TestComponent.generated.h"
+
+UCLASS()
+class USpatialTypeBinding_TestComponent : public USpatialTypeBinding
+{
+	GENERATED_BODY()
+
+public:
+	const FRepHandlePropertyMap& GetRepHandlePropertyMap() const override;
+	const FHandoverHandlePropertyMap& GetHandoverHandlePropertyMap() const override;
+	UClass* GetBoundClass() const override;
+
+	void Init(USpatialInterop* InInterop, USpatialPackageMapClient* InPackageMap) override;
+	void BindToView(bool bIsClient) override;
+	void UnbindFromView() override;
+
+	worker::Entity CreateActorEntity(const FString& ClientWorkerId, const FVector& Position, const FString& Metadata, const FPropertyChangeState& InitialChanges, USpatialActorChannel* Channel) const override;
+	void SendComponentUpdates(const FPropertyChangeState& Changes, USpatialActorChannel* Channel, const FEntityId& EntityId) const override;
+	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
+
+	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+
+	void BuildSpatialComponentUpdate(
+		const FPropertyChangeState& Changes,
+		USpatialActorChannel* Channel,
+		improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update& SingleClientUpdate,
+		bool& bSingleClientUpdateChanged,
+		improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update& MultiClientUpdate,
+		bool& bMultiClientUpdateChanged,
+		improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update& HandoverDataUpdate,
+		bool& bHandoverDataUpdateChanged) const;
+
+private:
+	improbable::unreal::callbacks::FScopedViewCallbacks ViewCallbacks;
+
+	// RPC to sender map.
+	using FRPCSender = void (USpatialTypeBinding_TestComponent::*)(worker::Connection* const, void*, UObject*);
+	TMap<FName, FRPCSender> RPCToSenderMap;
+
+	FRepHandlePropertyMap RepHandleToPropertyMap;
+	FHandoverHandlePropertyMap HandoverHandleToPropertyMap;
+
+	void ServerSendUpdate_SingleClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update& OutUpdate) const;
+	void ServerSendUpdate_MultiClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update& OutUpdate) const;
+	void ServerSendUpdate_Handover(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update& OutUpdate) const;
+	void ReceiveUpdate_SingleClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update& Update) const;
+	void ReceiveUpdate_MultiClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update& Update) const;
+	void ReceiveUpdate_Handover(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update& Update) const;
+	void ReceiveUpdate_NetMulticastRPCs(worker::EntityId EntityId, const improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs::Update& Update);
+
+	// RPC command sender functions.
+
+	// RPC command request handler functions.
+
+	// RPC command response handler functions.
+};

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.cpp
@@ -1,0 +1,1337 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+
+#include "SpatialTypeBinding_TestStaticComponentReplication.h"
+
+#include "GameFramework/PlayerState.h"
+#include "NetworkGuid.h"
+
+#include "SpatialOS.h"
+#include "EntityBuilder.h"
+
+#include "SpatialConstants.h"
+#include "SpatialConditionMapFilter.h"
+#include "SpatialUnrealObjectRef.h"
+#include "SpatialActorChannel.h"
+#include "SpatialPackageMapClient.h"
+#include "SpatialMemoryReader.h"
+#include "SpatialMemoryWriter.h"
+#include "SpatialNetDriver.h"
+#include "SpatialInterop.h"
+#include "Tests/TestStaticComponentReplication.h"
+
+#include "TestStaticComponentReplicationSingleClientRepDataAddComponentOp.h"
+#include "TestStaticComponentReplicationMultiClientRepDataAddComponentOp.h"
+#include "TestStaticComponentReplicationHandoverDataAddComponentOp.h"
+
+#include "SpatialTypeBinding_TestComponent.h"
+#include "TestComponentSingleClientRepDataAddComponentOp.h"
+#include "TestComponentMultiClientRepDataAddComponentOp.h"
+#include "TestComponentHandoverDataAddComponentOp.h"
+
+const FRepHandlePropertyMap& USpatialTypeBinding_TestStaticComponentReplication::GetRepHandlePropertyMap() const
+{
+	return RepHandleToPropertyMap;
+}
+
+const FHandoverHandlePropertyMap& USpatialTypeBinding_TestStaticComponentReplication::GetHandoverHandlePropertyMap() const
+{
+	return HandoverHandleToPropertyMap;
+}
+
+UClass* USpatialTypeBinding_TestStaticComponentReplication::GetBoundClass() const
+{
+	return ATestStaticComponentReplication::StaticClass();
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::Init(USpatialInterop* InInterop, USpatialPackageMapClient* InPackageMap)
+{
+	Super::Init(InInterop, InPackageMap);
+
+	RPCToSenderMap.Emplace("Server_ReportReplication", &USpatialTypeBinding_TestStaticComponentReplication::Server_ReportReplication_SendRPC);
+
+	UClass* Class = FindObject<UClass>(ANY_PACKAGE, TEXT("TestStaticComponentReplication"));
+
+	// Populate RepHandleToPropertyMap.
+	RepHandleToPropertyMap.Add(1, FRepHandleData(Class, {"bHidden"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(2, FRepHandleData(Class, {"bReplicateMovement"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(3, FRepHandleData(Class, {"bTearOff"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(4, FRepHandleData(Class, {"bCanBeDamaged"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(5, FRepHandleData(Class, {"RemoteRole"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(6, FRepHandleData(Class, {"ReplicatedMovement"}, {0}, COND_SimulatedOrPhysics, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(7, FRepHandleData(Class, {"AttachmentReplication", "AttachParent"}, {0, 0}, COND_Custom, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(8, FRepHandleData(Class, {"AttachmentReplication", "LocationOffset"}, {0, 0}, COND_Custom, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(9, FRepHandleData(Class, {"AttachmentReplication", "RelativeScale3D"}, {0, 0}, COND_Custom, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(10, FRepHandleData(Class, {"AttachmentReplication", "RotationOffset"}, {0, 0}, COND_Custom, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(11, FRepHandleData(Class, {"AttachmentReplication", "AttachSocket"}, {0, 0}, COND_Custom, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(12, FRepHandleData(Class, {"AttachmentReplication", "AttachComponent"}, {0, 0}, COND_Custom, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(13, FRepHandleData(Class, {"Owner"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(14, FRepHandleData(Class, {"Role"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(15, FRepHandleData(Class, {"Instigator"}, {0}, COND_None, REPNOTIFY_OnChanged));
+	RepHandleToPropertyMap.Add(16, FRepHandleData(Class, {"TestBookend"}, {0}, COND_None, REPNOTIFY_OnChanged));
+
+	bIsSingleton = false;
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::BindToView(bool bIsClient)
+{
+	TSharedPtr<worker::View> View = Interop->GetSpatialOS()->GetView().Pin();
+	ViewCallbacks.Init(View);
+
+	if (Interop->GetNetDriver()->GetNetMode() == NM_Client)
+	{
+		ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData>([this](
+			const worker::ComponentUpdateOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData>& Op)
+		{
+			// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+			if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::ComponentId))
+			{
+				return;
+			}
+			USpatialActorChannel* ActorChannel = Interop->GetActorChannelByEntityId(Op.EntityId);
+			check(ActorChannel);
+			ReceiveUpdate_SingleClient(ActorChannel, Op.Update);
+		}));
+		ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData>([this](
+			const worker::ComponentUpdateOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData>& Op)
+		{
+			// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+			if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::ComponentId))
+			{
+				return;
+			}
+			USpatialActorChannel* ActorChannel = Interop->GetActorChannelByEntityId(Op.EntityId);
+			check(ActorChannel);
+			ReceiveUpdate_MultiClient(ActorChannel, Op.Update);
+		}));
+		if (!bIsClient)
+		{
+			ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData>([this](
+				const worker::ComponentUpdateOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData>& Op)
+			{
+				// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+				if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::ComponentId))
+				{
+					return;
+				}
+				USpatialActorChannel* ActorChannel = Interop->GetActorChannelByEntityId(Op.EntityId);
+				check(ActorChannel);
+				ReceiveUpdate_Handover(ActorChannel, Op.Update);
+			}));
+		}
+	}
+	ViewCallbacks.Add(View->OnComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs>([this](
+		const worker::ComponentUpdateOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs>& Op)
+	{
+		// TODO: Remove this check once we can disable component update short circuiting. This will be exposed in 14.0. See TIG-137.
+		if (HasComponentAuthority(Interop->GetSpatialOS()->GetView(), Op.EntityId, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs::ComponentId))
+		{
+			return;
+		}
+		ReceiveUpdate_NetMulticastRPCs(Op.EntityId, Op.Update);
+	}));
+
+	using ServerRPCCommandTypes = improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands;
+	ViewCallbacks.Add(View->OnCommandRequest<ServerRPCCommandTypes::Serverreportreplication>(std::bind(&USpatialTypeBinding_TestStaticComponentReplication::Server_ReportReplication_OnRPCPayload, this, std::placeholders::_1)));
+	ViewCallbacks.Add(View->OnCommandResponse<ServerRPCCommandTypes::Serverreportreplication>(std::bind(&USpatialTypeBinding_TestStaticComponentReplication::Server_ReportReplication_OnCommandResponse, this, std::placeholders::_1)));
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::UnbindFromView()
+{
+	ViewCallbacks.Reset();
+}
+
+worker::Entity USpatialTypeBinding_TestStaticComponentReplication::CreateActorEntity(const FString& ClientWorkerId, const FVector& Position, const FString& Metadata, const FPropertyChangeState& InitialChanges, USpatialActorChannel* Channel) const
+{
+	// Validate replication list.
+	const uint16 RepHandlePropertyMapCount = GetRepHandlePropertyMap().Num();
+	for (auto& Rep : InitialChanges.RepChanged)
+	{
+		checkf(Rep <= RepHandlePropertyMapCount, TEXT("Attempting to replicate a property with a handle that the type binding is not aware of. Have additional replicated properties been added in a non generated child object?"))
+	}
+
+	// Setup initial data.
+
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Data SingleClientTestStaticComponentReplicationData;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update SingleClientTestStaticComponentReplicationUpdate;
+	bool bSingleClientTestStaticComponentReplicationUpdateChanged = false;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Data MultiClientTestStaticComponentReplicationData;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update MultiClientTestStaticComponentReplicationUpdate;
+	bool bMultiClientTestStaticComponentReplicationUpdateChanged = false;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Data TestStaticComponentReplicationHandoverData;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update TestStaticComponentReplicationHandoverDataUpdate;
+	bool bTestStaticComponentReplicationHandoverDataUpdateChanged = false;
+
+	BuildSpatialComponentUpdate(InitialChanges, Channel, SingleClientTestStaticComponentReplicationUpdate, bSingleClientTestStaticComponentReplicationUpdateChanged, MultiClientTestStaticComponentReplicationUpdate, bMultiClientTestStaticComponentReplicationUpdateChanged, TestStaticComponentReplicationHandoverDataUpdate, bTestStaticComponentReplicationHandoverDataUpdateChanged);
+	SingleClientTestStaticComponentReplicationUpdate.ApplyTo(SingleClientTestStaticComponentReplicationData);
+	MultiClientTestStaticComponentReplicationUpdate.ApplyTo(MultiClientTestStaticComponentReplicationData);
+	TestStaticComponentReplicationHandoverDataUpdate.ApplyTo(TestStaticComponentReplicationHandoverData);
+
+	improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Data SingleClientTestComponentData;
+	improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::Update SingleClientTestComponentUpdate;
+	bool bSingleClientTestComponentUpdateChanged = false;
+	improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Data MultiClientTestComponentData;
+	improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData::Update MultiClientTestComponentUpdate;
+	bool bMultiClientTestComponentUpdateChanged = false;
+	improbable::unreal::generated::testcomponent::TestComponentHandoverData::Data TestComponentHandoverData;
+	improbable::unreal::generated::testcomponent::TestComponentHandoverData::Update TestComponentHandoverDataUpdate;
+	bool bTestComponentHandoverDataUpdateChanged = false;
+
+	FPropertyChangeState TestComponentChangeState = Channel->CreateSubobjectChangeState(Channel->Actor->FindComponentByClass<UTestComponent>());
+	USpatialTypeBinding_TestComponent* TestComponentTypeBinding = Cast<USpatialTypeBinding_TestComponent>(Interop->GetTypeBindingByClass(UTestComponent::StaticClass()));
+	TestComponentTypeBinding->BuildSpatialComponentUpdate(TestComponentChangeState, Channel, SingleClientTestComponentUpdate, bSingleClientTestComponentUpdateChanged, MultiClientTestComponentUpdate, bMultiClientTestComponentUpdateChanged, TestComponentHandoverDataUpdate, bTestComponentHandoverDataUpdateChanged);
+	SingleClientTestComponentUpdate.ApplyTo(SingleClientTestComponentData);
+	MultiClientTestComponentUpdate.ApplyTo(MultiClientTestComponentData);
+	TestComponentHandoverDataUpdate.ApplyTo(TestComponentHandoverData);
+
+	// Create entity.
+	std::string ClientWorkerIdString = TCHAR_TO_UTF8(*ClientWorkerId);
+
+	improbable::WorkerAttributeSet WorkerAttribute{{worker::List<std::string>{"UnrealWorker"}}};
+	improbable::WorkerAttributeSet ClientAttribute{{worker::List<std::string>{"UnrealClient"}}};
+	improbable::WorkerAttributeSet OwningClientAttribute{{"workerId:" + ClientWorkerIdString}};
+
+	improbable::WorkerRequirementSet WorkersOnly{{WorkerAttribute}};
+	improbable::WorkerRequirementSet ClientsOnly{{ClientAttribute}};
+	improbable::WorkerRequirementSet OwningClientOnly{{OwningClientAttribute}};
+	improbable::WorkerRequirementSet AnyUnrealWorkerOrClient{{WorkerAttribute, ClientAttribute}};
+	improbable::WorkerRequirementSet AnyUnrealWorkerOrOwningClient{{WorkerAttribute, OwningClientAttribute}};
+
+	// Set up unreal metadata.
+	improbable::unreal::UnrealMetadata::Data UnrealMetadata;
+	if (Channel->Actor->IsFullNameStableForNetworking())
+	{
+		UnrealMetadata.set_static_path({std::string{TCHAR_TO_UTF8(*Channel->Actor->GetPathName(Channel->Actor->GetWorld()))}});
+	}
+	if (!ClientWorkerIdString.empty())
+	{
+		UnrealMetadata.set_owner_worker_id({ClientWorkerIdString});
+	}
+
+	uint32 CurrentOffset = 1;
+	worker::Map<std::string, std::uint32_t> SubobjectNameToOffset;
+	ForEachObjectWithOuter(Channel->Actor, [&UnrealMetadata, &CurrentOffset, &SubobjectNameToOffset](UObject* Object)
+	{
+		// Objects can only be allocated NetGUIDs if this is true.
+		if (Object->IsSupportedForNetworking() && !Object->IsPendingKill() && !Object->IsEditorOnly())
+		{
+			SubobjectNameToOffset.emplace(TCHAR_TO_UTF8(*(Object->GetName())), CurrentOffset);
+			CurrentOffset++;
+		}
+	});
+	UnrealMetadata.set_subobject_name_to_offset(SubobjectNameToOffset);
+
+	// Build entity.
+	const improbable::Coordinates SpatialPosition = SpatialConstants::LocationToSpatialOSCoordinates(Position);
+	return improbable::unreal::FEntityBuilder::Begin()
+		.AddPositionComponent(improbable::Position::Data{SpatialPosition}, WorkersOnly)
+		.AddMetadataComponent(improbable::Metadata::Data{TCHAR_TO_UTF8(*Metadata)})
+		.SetPersistence(true)
+		.SetReadAcl(AnyUnrealWorkerOrClient)
+		.AddComponent<improbable::unreal::UnrealMetadata>(UnrealMetadata, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData>(SingleClientTestStaticComponentReplicationData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData>(MultiClientTestStaticComponentReplicationData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData>(TestStaticComponentReplicationHandoverData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationClientRPCs>(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationClientRPCs::Data{}, OwningClientOnly)
+		.AddComponent<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs>(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Data{}, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs>(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs::Data{}, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData>(SingleClientTestComponentData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentMultiClientRepData>(MultiClientTestComponentData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentHandoverData>(TestComponentHandoverData, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentClientRPCs>(improbable::unreal::generated::testcomponent::TestComponentClientRPCs::Data{}, OwningClientOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentServerRPCs>(improbable::unreal::generated::testcomponent::TestComponentServerRPCs::Data{}, WorkersOnly)
+		.AddComponent<improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs>(improbable::unreal::generated::testcomponent::TestComponentNetMulticastRPCs::Data{}, WorkersOnly)
+		.Build();
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::SendComponentUpdates(const FPropertyChangeState& Changes, USpatialActorChannel* Channel, const FEntityId& EntityId) const
+{
+	// Build SpatialOS updates.
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update SingleClientUpdate;
+	bool bSingleClientUpdateChanged = false;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update MultiClientUpdate;
+	bool bMultiClientUpdateChanged = false;
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update HandoverDataUpdate;
+	bool bHandoverDataUpdateChanged = false;
+	BuildSpatialComponentUpdate(Changes, Channel, SingleClientUpdate, bSingleClientUpdateChanged, MultiClientUpdate, bMultiClientUpdateChanged, HandoverDataUpdate, bHandoverDataUpdateChanged);
+
+	// Send SpatialOS updates if anything changed.
+	TSharedPtr<worker::Connection> Connection = Interop->GetSpatialOS()->GetConnection().Pin();
+	if (bSingleClientUpdateChanged)
+	{
+		Connection->SendComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData>(EntityId.ToSpatialEntityId(), SingleClientUpdate);
+	}
+	if (bMultiClientUpdateChanged)
+	{
+		Connection->SendComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData>(EntityId.ToSpatialEntityId(), MultiClientUpdate);
+	}
+	if (bHandoverDataUpdateChanged)
+	{
+		Connection->SendComponentUpdate<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData>(EntityId.ToSpatialEntityId(), HandoverDataUpdate);
+	}
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters)
+{
+	TSharedPtr<worker::Connection> Connection = Interop->GetSpatialOS()->GetConnection().Pin();
+	auto SenderFuncIterator = RPCToSenderMap.Find(Function->GetFName());
+	if (SenderFuncIterator == nullptr)
+	{
+		UE_LOG(LogSpatialGDKInterop, Error, TEXT("Sender for %s has not been registered with RPCToSenderMap."), *Function->GetFName().ToString());
+		return;
+	}
+	checkf(*SenderFuncIterator, TEXT("Sender for %s has been registered as null."), *Function->GetFName().ToString());
+	(this->*(*SenderFuncIterator))(Connection.Get(), Parameters, TargetObject);
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const
+{
+	auto* SingleClientAddOp = Cast<UTestStaticComponentReplicationSingleClientRepDataAddComponentOp>(AddComponentOp);
+	if (SingleClientAddOp)
+	{
+		auto Update = improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update::FromInitialData(*SingleClientAddOp->Data.data());
+		ReceiveUpdate_SingleClient(Channel, Update);
+		return;
+	}
+	auto* MultiClientAddOp = Cast<UTestStaticComponentReplicationMultiClientRepDataAddComponentOp>(AddComponentOp);
+	if (MultiClientAddOp)
+	{
+		auto Update = improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update::FromInitialData(*MultiClientAddOp->Data.data());
+		ReceiveUpdate_MultiClient(Channel, Update);
+		return;
+	}
+	auto* HandoverDataAddOp = Cast<UTestStaticComponentReplicationHandoverDataAddComponentOp>(AddComponentOp);
+	if (HandoverDataAddOp)
+	{
+		auto Update = improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update::FromInitialData(*HandoverDataAddOp->Data.data());
+		ReceiveUpdate_Handover(Channel, Update);
+		return;
+	}
+
+	USpatialTypeBinding_TestComponent* TestComponentTypeBinding = Cast<USpatialTypeBinding_TestComponent>(Interop->GetTypeBindingByClass(UTestComponent::StaticClass()));
+	TestComponentTypeBinding->ReceiveAddComponent(Channel, AddComponentOp);
+}
+
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestStaticComponentReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+{
+	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
+	if (bIsClient)
+	{
+		if (!bAutonomousProxy)
+		{
+			Interest.emplace(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
+		}
+		Interest.emplace(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::ComponentId, worker::InterestOverride{false});
+	}
+	return Interest;
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::BuildSpatialComponentUpdate(
+	const FPropertyChangeState& Changes,
+	USpatialActorChannel* Channel,
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update& SingleClientUpdate,
+	bool& bSingleClientUpdateChanged,
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update& MultiClientUpdate,
+	bool& bMultiClientUpdateChanged,
+	improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update& HandoverDataUpdate,
+	bool& bHandoverDataUpdateChanged) const
+{
+	const FRepHandlePropertyMap& RepPropertyMap = GetRepHandlePropertyMap();
+	const FHandoverHandlePropertyMap& HandoverPropertyMap = GetHandoverHandlePropertyMap();
+	if (Changes.RepChanged.Num() > 0)
+	{
+		// Populate the replicated data component updates from the replicated property changelist.
+		FChangelistIterator ChangelistIterator(Changes.RepChanged, 0);
+		FRepHandleIterator HandleIterator(ChangelistIterator, Changes.RepCmds, Changes.RepBaseHandleToCmdIndex, 0, 1, 0, Changes.RepCmds.Num() - 1);
+		while (HandleIterator.NextHandle())
+		{
+			const FRepLayoutCmd& Cmd = Changes.RepCmds[HandleIterator.CmdIndex];
+			const FRepHandleData& PropertyMapData = RepPropertyMap[HandleIterator.Handle];
+			const uint8* Data = PropertyMapData.GetPropertyData(Changes.SourceData) + HandleIterator.ArrayOffset;
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Sending property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*Channel->Actor->GetName(),
+				Channel->GetEntityId().ToSpatialEntityId(),
+				*Cmd.Property->GetName(),
+				HandleIterator.Handle);
+			switch (GetGroupFromCondition(PropertyMapData.Condition))
+			{
+			case GROUP_SingleClient:
+				ServerSendUpdate_SingleClient(Data, HandleIterator.Handle, Cmd.Property, Channel, SingleClientUpdate);
+				bSingleClientUpdateChanged = true;
+				break;
+			case GROUP_MultiClient:
+				ServerSendUpdate_MultiClient(Data, HandleIterator.Handle, Cmd.Property, Channel, MultiClientUpdate);
+				bMultiClientUpdateChanged = true;
+				break;
+			}
+			if (Cmd.Type == REPCMD_DynamicArray)
+			{
+				if (!HandleIterator.JumpOverArray())
+				{
+					break;
+				}
+			}
+		}
+	}
+
+	// Populate the handover data component update from the handover property changelist.
+	for (uint16 ChangedHandle : Changes.HandoverChanged)
+	{
+		const FHandoverHandleData& PropertyMapData = HandoverPropertyMap[ChangedHandle];
+		const uint8* Data = PropertyMapData.GetPropertyData(Changes.SourceData);
+		UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Sending handover property update. actor %s (%lld), property %s (handle %d)"),
+			*Interop->GetSpatialOS()->GetWorkerId(),
+			*Channel->Actor->GetName(),
+			Channel->GetEntityId().ToSpatialEntityId(),
+			*PropertyMapData.Property->GetName(),
+			ChangedHandle);
+		ServerSendUpdate_Handover(Data, ChangedHandle, PropertyMapData.Property, Channel, HandoverDataUpdate);
+		bHandoverDataUpdateChanged = true;
+	}
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ServerSendUpdate_SingleClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update& OutUpdate) const
+{
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ServerSendUpdate_MultiClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update& OutUpdate) const
+{
+	switch (Handle)
+	{
+		case 1: // field_bhidden0
+		{
+			bool Value = static_cast<UBoolProperty*>(Property)->GetPropertyValue(Data);
+
+			OutUpdate.set_field_bhidden0(Value);
+			break;
+		}
+		case 2: // field_breplicatemovement0
+		{
+			bool Value = static_cast<UBoolProperty*>(Property)->GetPropertyValue(Data);
+
+			OutUpdate.set_field_breplicatemovement0(Value);
+			break;
+		}
+		case 3: // field_btearoff0
+		{
+			bool Value = static_cast<UBoolProperty*>(Property)->GetPropertyValue(Data);
+
+			OutUpdate.set_field_btearoff0(Value);
+			break;
+		}
+		case 4: // field_bcanbedamaged0
+		{
+			bool Value = static_cast<UBoolProperty*>(Property)->GetPropertyValue(Data);
+
+			OutUpdate.set_field_bcanbedamaged0(Value);
+			break;
+		}
+		case 5: // field_remoterole0
+		{
+			TEnumAsByte<ENetRole> Value = *(reinterpret_cast<TEnumAsByte<ENetRole> const*>(Data));
+
+			OutUpdate.set_field_remoterole0(uint32_t(Value));
+			break;
+		}
+		case 6: // field_replicatedmovement0
+		{
+			const FRepMovement& Value = *(reinterpret_cast<FRepMovement const*>(Data));
+
+			Interop->ResetOutgoingArrayRepUpdate_Internal(Channel, 6);
+			TSet<const UObject*> UnresolvedObjects;
+			TArray<uint8> ValueData;
+			FSpatialMemoryWriter ValueDataWriter(ValueData, PackageMap, UnresolvedObjects);
+			bool bSuccess = true;
+			(const_cast<FRepMovement&>(Value)).NetSerialize(ValueDataWriter, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FRepMovement failed."));
+			const std::string& Result = (std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
+			if (UnresolvedObjects.Num() == 0)
+			{
+				OutUpdate.set_field_replicatedmovement0(Result);
+			}
+			else
+			{
+				Interop->QueueOutgoingArrayRepUpdate_Internal(UnresolvedObjects, Channel, 6);
+			}
+			break;
+		}
+		case 7: // field_attachmentreplication0_attachparent0
+		{
+			AActor* Value = *(reinterpret_cast<AActor* const*>(Data));
+
+			if (Value != nullptr)
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromObject(Value);
+				if (!NetGUID.IsValid())
+				{
+					if (Value->IsFullNameStableForNetworking())
+					{
+						NetGUID = PackageMap->ResolveStablyNamedObject(Value);
+					}
+				}
+				improbable::unreal::UnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
+				if (ObjectRef == SpatialConstants::UNRESOLVED_OBJECT_REF)
+				{
+					// A legal static object reference should never be unresolved.
+					check(!Value->IsFullNameStableForNetworking())
+					Interop->QueueOutgoingObjectRepUpdate_Internal(Value, Channel, 7);
+				}
+				else
+				{
+					OutUpdate.set_field_attachmentreplication0_attachparent0(ObjectRef);
+				}
+			}
+			else
+			{
+				OutUpdate.set_field_attachmentreplication0_attachparent0(SpatialConstants::NULL_OBJECT_REF);
+			}
+			break;
+		}
+		case 8: // field_attachmentreplication0_locationoffset0
+		{
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+
+			Interop->ResetOutgoingArrayRepUpdate_Internal(Channel, 8);
+			TSet<const UObject*> UnresolvedObjects;
+			TArray<uint8> ValueData;
+			FSpatialMemoryWriter ValueDataWriter(ValueData, PackageMap, UnresolvedObjects);
+			bool bSuccess = true;
+			(const_cast<FVector_NetQuantize100&>(Value)).NetSerialize(ValueDataWriter, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FVector_NetQuantize100 failed."));
+			const std::string& Result = (std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
+			if (UnresolvedObjects.Num() == 0)
+			{
+				OutUpdate.set_field_attachmentreplication0_locationoffset0(Result);
+			}
+			else
+			{
+				Interop->QueueOutgoingArrayRepUpdate_Internal(UnresolvedObjects, Channel, 8);
+			}
+			break;
+		}
+		case 9: // field_attachmentreplication0_relativescale3d0
+		{
+			const FVector_NetQuantize100& Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(Data));
+
+			Interop->ResetOutgoingArrayRepUpdate_Internal(Channel, 9);
+			TSet<const UObject*> UnresolvedObjects;
+			TArray<uint8> ValueData;
+			FSpatialMemoryWriter ValueDataWriter(ValueData, PackageMap, UnresolvedObjects);
+			bool bSuccess = true;
+			(const_cast<FVector_NetQuantize100&>(Value)).NetSerialize(ValueDataWriter, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FVector_NetQuantize100 failed."));
+			const std::string& Result = (std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
+			if (UnresolvedObjects.Num() == 0)
+			{
+				OutUpdate.set_field_attachmentreplication0_relativescale3d0(Result);
+			}
+			else
+			{
+				Interop->QueueOutgoingArrayRepUpdate_Internal(UnresolvedObjects, Channel, 9);
+			}
+			break;
+		}
+		case 10: // field_attachmentreplication0_rotationoffset0
+		{
+			const FRotator& Value = *(reinterpret_cast<FRotator const*>(Data));
+
+			Interop->ResetOutgoingArrayRepUpdate_Internal(Channel, 10);
+			TSet<const UObject*> UnresolvedObjects;
+			TArray<uint8> ValueData;
+			FSpatialMemoryWriter ValueDataWriter(ValueData, PackageMap, UnresolvedObjects);
+			bool bSuccess = true;
+			(const_cast<FRotator&>(Value)).NetSerialize(ValueDataWriter, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FRotator failed."));
+			const std::string& Result = (std::string(reinterpret_cast<char*>(ValueData.GetData()), ValueData.Num()));
+			if (UnresolvedObjects.Num() == 0)
+			{
+				OutUpdate.set_field_attachmentreplication0_rotationoffset0(Result);
+			}
+			else
+			{
+				Interop->QueueOutgoingArrayRepUpdate_Internal(UnresolvedObjects, Channel, 10);
+			}
+			break;
+		}
+		case 11: // field_attachmentreplication0_attachsocket0
+		{
+			FName Value = *(reinterpret_cast<FName const*>(Data));
+
+			OutUpdate.set_field_attachmentreplication0_attachsocket0(TCHAR_TO_UTF8(*Value.ToString()));
+			break;
+		}
+		case 12: // field_attachmentreplication0_attachcomponent0
+		{
+			USceneComponent* Value = *(reinterpret_cast<USceneComponent* const*>(Data));
+
+			if (Value != nullptr)
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromObject(Value);
+				if (!NetGUID.IsValid())
+				{
+					if (Value->IsFullNameStableForNetworking())
+					{
+						NetGUID = PackageMap->ResolveStablyNamedObject(Value);
+					}
+				}
+				improbable::unreal::UnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
+				if (ObjectRef == SpatialConstants::UNRESOLVED_OBJECT_REF)
+				{
+					// A legal static object reference should never be unresolved.
+					check(!Value->IsFullNameStableForNetworking())
+					Interop->QueueOutgoingObjectRepUpdate_Internal(Value, Channel, 12);
+				}
+				else
+				{
+					OutUpdate.set_field_attachmentreplication0_attachcomponent0(ObjectRef);
+				}
+			}
+			else
+			{
+				OutUpdate.set_field_attachmentreplication0_attachcomponent0(SpatialConstants::NULL_OBJECT_REF);
+			}
+			break;
+		}
+		case 13: // field_owner0
+		{
+			AActor* Value = *(reinterpret_cast<AActor* const*>(Data));
+
+			if (Value != nullptr)
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromObject(Value);
+				if (!NetGUID.IsValid())
+				{
+					if (Value->IsFullNameStableForNetworking())
+					{
+						NetGUID = PackageMap->ResolveStablyNamedObject(Value);
+					}
+				}
+				improbable::unreal::UnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
+				if (ObjectRef == SpatialConstants::UNRESOLVED_OBJECT_REF)
+				{
+					// A legal static object reference should never be unresolved.
+					check(!Value->IsFullNameStableForNetworking())
+					Interop->QueueOutgoingObjectRepUpdate_Internal(Value, Channel, 13);
+				}
+				else
+				{
+					OutUpdate.set_field_owner0(ObjectRef);
+				}
+			}
+			else
+			{
+				OutUpdate.set_field_owner0(SpatialConstants::NULL_OBJECT_REF);
+			}
+			break;
+		}
+		case 14: // field_role0
+		{
+			TEnumAsByte<ENetRole> Value = *(reinterpret_cast<TEnumAsByte<ENetRole> const*>(Data));
+
+			OutUpdate.set_field_role0(uint32_t(Value));
+			break;
+		}
+		case 15: // field_instigator0
+		{
+			APawn* Value = *(reinterpret_cast<APawn* const*>(Data));
+
+			if (Value != nullptr)
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromObject(Value);
+				if (!NetGUID.IsValid())
+				{
+					if (Value->IsFullNameStableForNetworking())
+					{
+						NetGUID = PackageMap->ResolveStablyNamedObject(Value);
+					}
+				}
+				improbable::unreal::UnrealObjectRef ObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(NetGUID);
+				if (ObjectRef == SpatialConstants::UNRESOLVED_OBJECT_REF)
+				{
+					// A legal static object reference should never be unresolved.
+					check(!Value->IsFullNameStableForNetworking())
+					Interop->QueueOutgoingObjectRepUpdate_Internal(Value, Channel, 15);
+				}
+				else
+				{
+					OutUpdate.set_field_instigator0(ObjectRef);
+				}
+			}
+			else
+			{
+				OutUpdate.set_field_instigator0(SpatialConstants::NULL_OBJECT_REF);
+			}
+			break;
+		}
+		case 16: // field_testbookend0
+		{
+			int32 Value = *(reinterpret_cast<int32 const*>(Data));
+
+			OutUpdate.set_field_testbookend0(int32_t(Value));
+			break;
+		}
+	default:
+		checkf(false, TEXT("Unknown replication handle %d encountered when creating a SpatialOS update."));
+		break;
+	}
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ServerSendUpdate_Handover(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update& OutUpdate) const
+{
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ReceiveUpdate_SingleClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update& Update) const
+{
+	AActor* TargetObject = ActorChannel->Actor;
+	ActorChannel->PreReceiveSpatialUpdate(TargetObject);
+	TArray<UProperty*> RepNotifies;
+	ActorChannel->PostReceiveSpatialUpdate(TargetObject, RepNotifies);
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ReceiveUpdate_MultiClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update& Update) const
+{
+	AActor* TargetObject = ActorChannel->Actor;
+	ActorChannel->PreReceiveSpatialUpdate(TargetObject);
+	TSet<UProperty*> RepNotifies;
+
+	const bool bIsServer = Interop->GetNetDriver()->IsServer();
+	const bool bAutonomousProxy = ActorChannel->IsClientAutonomousProxy(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationClientRPCs::ComponentId);
+	const FRepHandlePropertyMap& HandleToPropertyMap = GetRepHandlePropertyMap();
+	FSpatialConditionMapFilter ConditionMap(ActorChannel, bAutonomousProxy);
+
+	if (!Update.field_bhidden0().empty())
+	{
+		// field_bhidden0
+		uint16 Handle = 1;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			bool Value = static_cast<UBoolProperty*>(RepData->Property)->GetPropertyValue(PropertyData);
+
+			Value = (*Update.field_bhidden0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_breplicatemovement0().empty())
+	{
+		// field_breplicatemovement0
+		uint16 Handle = 2;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			bool Value = static_cast<UBoolProperty*>(RepData->Property)->GetPropertyValue(PropertyData);
+
+			Value = (*Update.field_breplicatemovement0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_btearoff0().empty())
+	{
+		// field_btearoff0
+		uint16 Handle = 3;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			bool Value = static_cast<UBoolProperty*>(RepData->Property)->GetPropertyValue(PropertyData);
+
+			Value = (*Update.field_btearoff0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_bcanbedamaged0().empty())
+	{
+		// field_bcanbedamaged0
+		uint16 Handle = 4;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			bool Value = static_cast<UBoolProperty*>(RepData->Property)->GetPropertyValue(PropertyData);
+
+			Value = (*Update.field_bcanbedamaged0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_remoterole0().empty())
+	{
+		// field_remoterole0
+		uint16 Handle = 5;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			// On the client, we need to swap Role/RemoteRole.
+			if (!bIsServer)
+			{
+				Handle = 14;
+				RepData = &HandleToPropertyMap[Handle];
+			}
+
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			TEnumAsByte<ENetRole> Value = *(reinterpret_cast<TEnumAsByte<ENetRole> const*>(PropertyData));
+
+			Value = TEnumAsByte<ENetRole>(uint8((*Update.field_remoterole0().data())));
+
+			// Downgrade role from AutonomousProxy to SimulatedProxy if we aren't authoritative over
+			// the server RPCs component.
+			if (!bIsServer && Value == ROLE_AutonomousProxy && !bAutonomousProxy)
+			{
+				Value = ROLE_SimulatedProxy;
+			}
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_replicatedmovement0().empty())
+	{
+		// field_replicatedmovement0
+		uint16 Handle = 6;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			FRepMovement Value = *(reinterpret_cast<FRepMovement const*>(PropertyData));
+
+			auto& ValueDataStr = (*Update.field_replicatedmovement0().data());
+			TArray<uint8> ValueData;
+			ValueData.Append(reinterpret_cast<const uint8*>(ValueDataStr.data()), ValueDataStr.size());
+			FSpatialMemoryReader ValueDataReader(ValueData, PackageMap);
+			bool bSuccess = true;
+			Value.NetSerialize(ValueDataReader, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FRepMovement failed."));
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_attachmentreplication0_attachparent0().empty())
+	{
+		// field_attachmentreplication0_attachparent0
+		uint16 Handle = 7;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			bool bWriteObjectProperty = true;
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			AActor* Value = *(reinterpret_cast<AActor* const*>(PropertyData));
+
+			improbable::unreal::UnrealObjectRef ObjectRef = (*Update.field_attachmentreplication0_attachparent0().data());
+			check(ObjectRef != SpatialConstants::UNRESOLVED_OBJECT_REF);
+			if (ObjectRef == SpatialConstants::NULL_OBJECT_REF)
+			{
+				Value = nullptr;
+			}
+			else
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromUnrealObjectRef(ObjectRef);
+				if (NetGUID.IsValid())
+				{
+					UObject* Object_Raw = PackageMap->GetObjectFromNetGUID(NetGUID, true);
+					checkf(Object_Raw, TEXT("An object ref %s should map to a valid object."), *ObjectRefToString(ObjectRef));
+					checkf(Cast<AActor>(Object_Raw), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRefToString(ObjectRef), *Object_Raw->GetFullName());
+					Value = Cast<AActor>(Object_Raw);
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: Received unresolved object property. Value: %s. actor %s (%lld), property %s (handle %d)"),
+						*Interop->GetSpatialOS()->GetWorkerId(),
+						*ObjectRefToString(ObjectRef),
+						*ActorChannel->Actor->GetName(),
+						ActorChannel->GetEntityId().ToSpatialEntityId(),
+						*RepData->Property->GetName(),
+						Handle);
+					// A legal static object reference should never be unresolved.
+					check(ObjectRef.path().empty());
+					bWriteObjectProperty = false;
+					Interop->QueueIncomingObjectRepUpdate_Internal(ObjectRef, ActorChannel, RepData);
+				}
+			}
+
+			if (bWriteObjectProperty)
+			{
+				ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+				UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+					*Interop->GetSpatialOS()->GetWorkerId(),
+					*ActorChannel->Actor->GetName(),
+					ActorChannel->GetEntityId().ToSpatialEntityId(),
+					*RepData->Property->GetName(),
+					Handle);
+			}
+		}
+	}
+	if (!Update.field_attachmentreplication0_locationoffset0().empty())
+	{
+		// field_attachmentreplication0_locationoffset0
+		uint16 Handle = 8;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(PropertyData));
+
+			auto& ValueDataStr = (*Update.field_attachmentreplication0_locationoffset0().data());
+			TArray<uint8> ValueData;
+			ValueData.Append(reinterpret_cast<const uint8*>(ValueDataStr.data()), ValueDataStr.size());
+			FSpatialMemoryReader ValueDataReader(ValueData, PackageMap);
+			bool bSuccess = true;
+			Value.NetSerialize(ValueDataReader, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FVector_NetQuantize100 failed."));
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_attachmentreplication0_relativescale3d0().empty())
+	{
+		// field_attachmentreplication0_relativescale3d0
+		uint16 Handle = 9;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			FVector_NetQuantize100 Value = *(reinterpret_cast<FVector_NetQuantize100 const*>(PropertyData));
+
+			auto& ValueDataStr = (*Update.field_attachmentreplication0_relativescale3d0().data());
+			TArray<uint8> ValueData;
+			ValueData.Append(reinterpret_cast<const uint8*>(ValueDataStr.data()), ValueDataStr.size());
+			FSpatialMemoryReader ValueDataReader(ValueData, PackageMap);
+			bool bSuccess = true;
+			Value.NetSerialize(ValueDataReader, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FVector_NetQuantize100 failed."));
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_attachmentreplication0_rotationoffset0().empty())
+	{
+		// field_attachmentreplication0_rotationoffset0
+		uint16 Handle = 10;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			FRotator Value = *(reinterpret_cast<FRotator const*>(PropertyData));
+
+			auto& ValueDataStr = (*Update.field_attachmentreplication0_rotationoffset0().data());
+			TArray<uint8> ValueData;
+			ValueData.Append(reinterpret_cast<const uint8*>(ValueDataStr.data()), ValueDataStr.size());
+			FSpatialMemoryReader ValueDataReader(ValueData, PackageMap);
+			bool bSuccess = true;
+			Value.NetSerialize(ValueDataReader, PackageMap, bSuccess);
+			checkf(bSuccess, TEXT("NetSerialize on FRotator failed."));
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_attachmentreplication0_attachsocket0().empty())
+	{
+		// field_attachmentreplication0_attachsocket0
+		uint16 Handle = 11;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			FName Value = *(reinterpret_cast<FName const*>(PropertyData));
+
+			Value = FName(((*Update.field_attachmentreplication0_attachsocket0().data())).data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_attachmentreplication0_attachcomponent0().empty())
+	{
+		// field_attachmentreplication0_attachcomponent0
+		uint16 Handle = 12;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			bool bWriteObjectProperty = true;
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			USceneComponent* Value = *(reinterpret_cast<USceneComponent* const*>(PropertyData));
+
+			improbable::unreal::UnrealObjectRef ObjectRef = (*Update.field_attachmentreplication0_attachcomponent0().data());
+			check(ObjectRef != SpatialConstants::UNRESOLVED_OBJECT_REF);
+			if (ObjectRef == SpatialConstants::NULL_OBJECT_REF)
+			{
+				Value = nullptr;
+			}
+			else
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromUnrealObjectRef(ObjectRef);
+				if (NetGUID.IsValid())
+				{
+					UObject* Object_Raw = PackageMap->GetObjectFromNetGUID(NetGUID, true);
+					checkf(Object_Raw, TEXT("An object ref %s should map to a valid object."), *ObjectRefToString(ObjectRef));
+					checkf(Cast<USceneComponent>(Object_Raw), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRefToString(ObjectRef), *Object_Raw->GetFullName());
+					Value = Cast<USceneComponent>(Object_Raw);
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: Received unresolved object property. Value: %s. actor %s (%lld), property %s (handle %d)"),
+						*Interop->GetSpatialOS()->GetWorkerId(),
+						*ObjectRefToString(ObjectRef),
+						*ActorChannel->Actor->GetName(),
+						ActorChannel->GetEntityId().ToSpatialEntityId(),
+						*RepData->Property->GetName(),
+						Handle);
+					// A legal static object reference should never be unresolved.
+					check(ObjectRef.path().empty());
+					bWriteObjectProperty = false;
+					Interop->QueueIncomingObjectRepUpdate_Internal(ObjectRef, ActorChannel, RepData);
+				}
+			}
+
+			if (bWriteObjectProperty)
+			{
+				ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+				UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+					*Interop->GetSpatialOS()->GetWorkerId(),
+					*ActorChannel->Actor->GetName(),
+					ActorChannel->GetEntityId().ToSpatialEntityId(),
+					*RepData->Property->GetName(),
+					Handle);
+			}
+		}
+	}
+	if (!Update.field_owner0().empty())
+	{
+		// field_owner0
+		uint16 Handle = 13;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			bool bWriteObjectProperty = true;
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			AActor* Value = *(reinterpret_cast<AActor* const*>(PropertyData));
+
+			improbable::unreal::UnrealObjectRef ObjectRef = (*Update.field_owner0().data());
+			check(ObjectRef != SpatialConstants::UNRESOLVED_OBJECT_REF);
+			if (ObjectRef == SpatialConstants::NULL_OBJECT_REF)
+			{
+				Value = nullptr;
+			}
+			else
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromUnrealObjectRef(ObjectRef);
+				if (NetGUID.IsValid())
+				{
+					UObject* Object_Raw = PackageMap->GetObjectFromNetGUID(NetGUID, true);
+					checkf(Object_Raw, TEXT("An object ref %s should map to a valid object."), *ObjectRefToString(ObjectRef));
+					checkf(Cast<AActor>(Object_Raw), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRefToString(ObjectRef), *Object_Raw->GetFullName());
+					Value = Cast<AActor>(Object_Raw);
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: Received unresolved object property. Value: %s. actor %s (%lld), property %s (handle %d)"),
+						*Interop->GetSpatialOS()->GetWorkerId(),
+						*ObjectRefToString(ObjectRef),
+						*ActorChannel->Actor->GetName(),
+						ActorChannel->GetEntityId().ToSpatialEntityId(),
+						*RepData->Property->GetName(),
+						Handle);
+					// A legal static object reference should never be unresolved.
+					check(ObjectRef.path().empty());
+					bWriteObjectProperty = false;
+					Interop->QueueIncomingObjectRepUpdate_Internal(ObjectRef, ActorChannel, RepData);
+				}
+			}
+
+			if (bWriteObjectProperty)
+			{
+				ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+				UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+					*Interop->GetSpatialOS()->GetWorkerId(),
+					*ActorChannel->Actor->GetName(),
+					ActorChannel->GetEntityId().ToSpatialEntityId(),
+					*RepData->Property->GetName(),
+					Handle);
+			}
+		}
+	}
+	if (!Update.field_role0().empty())
+	{
+		// field_role0
+		uint16 Handle = 14;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			// On the client, we need to swap Role/RemoteRole.
+			if (!bIsServer)
+			{
+				Handle = 5;
+				RepData = &HandleToPropertyMap[Handle];
+			}
+
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			TEnumAsByte<ENetRole> Value = *(reinterpret_cast<TEnumAsByte<ENetRole> const*>(PropertyData));
+
+			Value = TEnumAsByte<ENetRole>(uint8((*Update.field_role0().data())));
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	if (!Update.field_instigator0().empty())
+	{
+		// field_instigator0
+		uint16 Handle = 15;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			bool bWriteObjectProperty = true;
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			APawn* Value = *(reinterpret_cast<APawn* const*>(PropertyData));
+
+			improbable::unreal::UnrealObjectRef ObjectRef = (*Update.field_instigator0().data());
+			check(ObjectRef != SpatialConstants::UNRESOLVED_OBJECT_REF);
+			if (ObjectRef == SpatialConstants::NULL_OBJECT_REF)
+			{
+				Value = nullptr;
+			}
+			else
+			{
+				FNetworkGUID NetGUID = PackageMap->GetNetGUIDFromUnrealObjectRef(ObjectRef);
+				if (NetGUID.IsValid())
+				{
+					UObject* Object_Raw = PackageMap->GetObjectFromNetGUID(NetGUID, true);
+					checkf(Object_Raw, TEXT("An object ref %s should map to a valid object."), *ObjectRefToString(ObjectRef));
+					checkf(Cast<APawn>(Object_Raw), TEXT("Object ref %s maps to object %s with the wrong class."), *ObjectRefToString(ObjectRef), *Object_Raw->GetFullName());
+					Value = Cast<APawn>(Object_Raw);
+				}
+				else
+				{
+					UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: Received unresolved object property. Value: %s. actor %s (%lld), property %s (handle %d)"),
+						*Interop->GetSpatialOS()->GetWorkerId(),
+						*ObjectRefToString(ObjectRef),
+						*ActorChannel->Actor->GetName(),
+						ActorChannel->GetEntityId().ToSpatialEntityId(),
+						*RepData->Property->GetName(),
+						Handle);
+					// A legal static object reference should never be unresolved.
+					check(ObjectRef.path().empty());
+					bWriteObjectProperty = false;
+					Interop->QueueIncomingObjectRepUpdate_Internal(ObjectRef, ActorChannel, RepData);
+				}
+			}
+
+			if (bWriteObjectProperty)
+			{
+				ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+				UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+					*Interop->GetSpatialOS()->GetWorkerId(),
+					*ActorChannel->Actor->GetName(),
+					ActorChannel->GetEntityId().ToSpatialEntityId(),
+					*RepData->Property->GetName(),
+					Handle);
+			}
+		}
+	}
+	if (!Update.field_testbookend0().empty())
+	{
+		// field_testbookend0
+		uint16 Handle = 16;
+		const FRepHandleData* RepData = &HandleToPropertyMap[Handle];
+		if (bIsServer || ConditionMap.IsRelevant(RepData->Condition))
+		{
+			uint8* PropertyData = RepData->GetPropertyData(reinterpret_cast<uint8*>(TargetObject));
+			int32 Value = *(reinterpret_cast<int32 const*>(PropertyData));
+
+			Value = (*Update.field_testbookend0().data());
+
+			ApplyIncomingReplicatedPropertyUpdate(*RepData, TargetObject, static_cast<const void*>(&Value), RepNotifies);
+
+			UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received replicated property update. actor %s (%lld), property %s (handle %d)"),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ActorChannel->Actor->GetName(),
+				ActorChannel->GetEntityId().ToSpatialEntityId(),
+				*RepData->Property->GetName(),
+				Handle);
+		}
+	}
+	ActorChannel->PostReceiveSpatialUpdate(TargetObject, RepNotifies.Array());
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ReceiveUpdate_Handover(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update& Update) const
+{
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::ReceiveUpdate_NetMulticastRPCs(worker::EntityId EntityId, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs::Update& Update)
+{
+}
+void USpatialTypeBinding_TestStaticComponentReplication::Server_ReportReplication_SendRPC(worker::Connection* const Connection, void* Parameters, UObject* TargetObject)
+{
+	// This struct is declared in TestStaticComponentReplication.generated.h (in a macro that is then put in TestStaticComponentReplication.h UCLASS macro)
+	TestStaticComponentReplication_eventServer_ReportReplication_Parms StructuredParams = *static_cast<TestStaticComponentReplication_eventServer_ReportReplication_Parms*>(Parameters);
+
+	auto Sender = [this, Connection, TargetObject, StructuredParams]() mutable -> FRPCCommandRequestResult
+	{
+		// Resolve TargetObject.
+		improbable::unreal::UnrealObjectRef TargetObjectRef = PackageMap->GetUnrealObjectRefFromNetGUID(PackageMap->GetNetGUIDFromObject(TargetObject));
+		if (TargetObjectRef == SpatialConstants::UNRESOLVED_OBJECT_REF)
+		{
+			UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: RPC Server_ReportReplication queued. Target object is unresolved."), *Interop->GetSpatialOS()->GetWorkerId());
+			return {TargetObject};
+		}
+
+		// Build RPC Payload.
+		improbable::unreal::generated::teststaticcomponentreplication::ServerReportReplicationRequest RPCPayload;
+		{
+			RPCPayload.set_field_repfloat0(StructuredParams.RepFloat);
+		}
+
+		// Send RPC
+		RPCPayload.set_target_subobject_offset(TargetObjectRef.offset());
+		UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Sending RPC: Server_ReportReplication, target: %s %s"),
+			*Interop->GetSpatialOS()->GetWorkerId(),
+			*TargetObject->GetName(),
+			*ObjectRefToString(TargetObjectRef));
+
+			auto RequestId = Connection->SendCommandRequest<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands::Serverreportreplication>(TargetObjectRef.entity(), RPCPayload, 0);
+			return {RequestId.Id};
+	};
+	Interop->InvokeRPCSendHandler_Internal(Sender, /*bReliable*/ true);
+}
+void USpatialTypeBinding_TestStaticComponentReplication::Server_ReportReplication_OnRPCPayload(const worker::CommandRequestOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands::Serverreportreplication>& Op)
+{
+	auto Receiver = [this, Op]() mutable -> FRPCCommandResponseResult
+	{
+		improbable::unreal::UnrealObjectRef TargetObjectRef{Op.EntityId, Op.Request.target_subobject_offset(), {}, {}};
+		FNetworkGUID TargetNetGUID = PackageMap->GetNetGUIDFromUnrealObjectRef(TargetObjectRef);
+		if (!TargetNetGUID.IsValid())
+		{
+			// A legal static object reference should never be unresolved.
+			checkf(TargetObjectRef.path().empty(), TEXT("A stably named object should not need resolution."));
+			UE_LOG(LogSpatialGDKInterop, Log, TEXT("%s: Server_ReportReplication_OnRPCPayload: Target object %s is not resolved on this worker."),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*ObjectRefToString(TargetObjectRef));
+			return {TargetObjectRef};
+		}
+		UObject* TargetObject = PackageMap->GetObjectFromNetGUID(TargetNetGUID, false);
+		checkf(TargetObject, TEXT("%s: Server_ReportReplication_OnRPCPayload: Object Ref %s (NetGUID %s) does not correspond to a UObject."),
+			*Interop->GetSpatialOS()->GetWorkerId(),
+			*ObjectRefToString(TargetObjectRef),
+			*TargetNetGUID.ToString());
+
+		// Declare parameters.
+		// This struct is declared in TestStaticComponentReplication.generated.h (in a macro that is then put in TestStaticComponentReplication.h UCLASS macro)
+		TestStaticComponentReplication_eventServer_ReportReplication_Parms Parameters;
+
+		// Extract from request data.
+		{
+			Parameters.RepFloat = Op.Request.field_repfloat0();
+		}
+
+		// Call implementation.
+		UE_LOG(LogSpatialGDKInterop, Verbose, TEXT("%s: Received RPC: Server_ReportReplication, target: %s %s"),
+			*Interop->GetSpatialOS()->GetWorkerId(),
+			*TargetObject->GetName(),
+			*ObjectRefToString(TargetObjectRef));
+
+		if (UFunction* Function = TargetObject->FindFunction(FName(TEXT("Server_ReportReplication"))))
+		{
+			TargetObject->ProcessEvent(Function, &Parameters);
+		}
+		else
+		{
+			UE_LOG(LogSpatialGDKInterop, Error, TEXT("%s: Server_ReportReplication_OnRPCPayload: Function not found. Object: %s, Function: Server_ReportReplication."),
+				*Interop->GetSpatialOS()->GetWorkerId(),
+				*TargetObject->GetFullName());
+		}
+
+		// Send command response.
+		TSharedPtr<worker::Connection> Connection = Interop->GetSpatialOS()->GetConnection().Pin();
+		Connection->SendCommandResponse<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands::Serverreportreplication>(Op.RequestId, {});
+		return {};
+	};
+	Interop->InvokeRPCReceiveHandler_Internal(Receiver);
+}
+
+void USpatialTypeBinding_TestStaticComponentReplication::Server_ReportReplication_OnCommandResponse(const worker::CommandResponseOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands::Serverreportreplication>& Op)
+{
+	Interop->HandleCommandResponse_Internal(TEXT("Server_ReportReplication"), Op.RequestId.Id, Op.EntityId, Op.StatusCode, FString(UTF8_TO_TCHAR(Op.Message.c_str())));
+}

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.h
@@ -1,0 +1,72 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+#pragma once
+
+#include "CoreMinimal.h"
+#include <improbable/worker.h>
+#include <improbable/view.h>
+#include <improbable/unreal/gdk/core_types.h>
+#include <improbable/unreal/gdk/unreal_metadata.h>
+#include <improbable/unreal/generated/UnrealTestStaticComponentReplication.h>
+#include "ScopedViewCallbacks.h"
+#include "SpatialTypeBinding.h"
+#include "SpatialTypeBinding_TestStaticComponentReplication.generated.h"
+
+UCLASS()
+class USpatialTypeBinding_TestStaticComponentReplication : public USpatialTypeBinding
+{
+	GENERATED_BODY()
+
+public:
+	const FRepHandlePropertyMap& GetRepHandlePropertyMap() const override;
+	const FHandoverHandlePropertyMap& GetHandoverHandlePropertyMap() const override;
+	UClass* GetBoundClass() const override;
+
+	void Init(USpatialInterop* InInterop, USpatialPackageMapClient* InPackageMap) override;
+	void BindToView(bool bIsClient) override;
+	void UnbindFromView() override;
+
+	worker::Entity CreateActorEntity(const FString& ClientWorkerId, const FVector& Position, const FString& Metadata, const FPropertyChangeState& InitialChanges, USpatialActorChannel* Channel) const override;
+	void SendComponentUpdates(const FPropertyChangeState& Changes, USpatialActorChannel* Channel, const FEntityId& EntityId) const override;
+	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
+
+	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+
+	void BuildSpatialComponentUpdate(
+		const FPropertyChangeState& Changes,
+		USpatialActorChannel* Channel,
+		improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update& SingleClientUpdate,
+		bool& bSingleClientUpdateChanged,
+		improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update& MultiClientUpdate,
+		bool& bMultiClientUpdateChanged,
+		improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update& HandoverDataUpdate,
+		bool& bHandoverDataUpdateChanged) const;
+
+private:
+	improbable::unreal::callbacks::FScopedViewCallbacks ViewCallbacks;
+
+	// RPC to sender map.
+	using FRPCSender = void (USpatialTypeBinding_TestStaticComponentReplication::*)(worker::Connection* const, void*, UObject*);
+	TMap<FName, FRPCSender> RPCToSenderMap;
+
+	FRepHandlePropertyMap RepHandleToPropertyMap;
+	FHandoverHandlePropertyMap HandoverHandleToPropertyMap;
+
+	void ServerSendUpdate_SingleClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update& OutUpdate) const;
+	void ServerSendUpdate_MultiClient(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update& OutUpdate) const;
+	void ServerSendUpdate_Handover(const uint8* RESTRICT Data, int32 Handle, UProperty* Property, USpatialActorChannel* Channel, improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update& OutUpdate) const;
+	void ReceiveUpdate_SingleClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::Update& Update) const;
+	void ReceiveUpdate_MultiClient(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationMultiClientRepData::Update& Update) const;
+	void ReceiveUpdate_Handover(USpatialActorChannel* ActorChannel, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::Update& Update) const;
+	void ReceiveUpdate_NetMulticastRPCs(worker::EntityId EntityId, const improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationNetMulticastRPCs::Update& Update);
+
+	// RPC command sender functions.
+	void Server_ReportReplication_SendRPC(worker::Connection* const Connection, void* Parameters, UObject* TargetObject);
+
+	// RPC command request handler functions.
+	void Server_ReportReplication_OnRPCPayload(const worker::CommandRequestOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands::Serverreportreplication>& Op);
+
+	// RPC command response handler functions.
+	void Server_ReportReplication_OnCommandResponse(const worker::CommandResponseOp<improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationServerRPCs::Commands::Serverreportreplication>& Op);
+};

--- a/Game/Source/TestSuite/Tests/GDKTestRunner.cpp
+++ b/Game/Source/TestSuite/Tests/GDKTestRunner.cpp
@@ -18,6 +18,7 @@
 #include "Tests/TestUStructReplication.h"
 #include "Tests/TestUObjectReplication.h"
 #include "Tests/TestMulticastRPC.h"
+#include "Tests/TestStaticComponentReplication.h"
 
 DEFINE_LOG_CATEGORY(LogSpatialGDKTests);
 
@@ -152,6 +153,7 @@ void AGDKTestRunner::Server_SetupTestCases()
 	AddTestCase<ATestUObjectReplication>();
 	AddTestCase<ATestUStructReplication>();
 	AddTestCase<ATestMulticastRPC>();
+	AddTestCase<ATestStaticComponentReplication>();
 }
 
 void AGDKTestRunner::Server_TearDownTestCases()

--- a/Game/Source/TestSuite/Tests/TestStaticComponentReplication.cpp
+++ b/Game/Source/TestSuite/Tests/TestStaticComponentReplication.cpp
@@ -31,11 +31,6 @@ ATestStaticComponentReplication::ATestStaticComponentReplication()
 	TestComponent->SetIsReplicated(true);
 }
 
-void ATestStaticComponentReplication::GetLifetimeReplicatedProps(TArray< FLifetimeProperty > & OutLifetimeProps) const
-{
-	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
-}
-
 bool ATestStaticComponentReplication::Server_ReportReplication_Validate(float RepFloat)
 {
 	return true;

--- a/Game/Source/TestSuite/Tests/TestStaticComponentReplication.cpp
+++ b/Game/Source/TestSuite/Tests/TestStaticComponentReplication.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+#include "TestStaticComponentReplication.h"
+
+#include "GameFramework/GameModeBase.h"
+#include "UnrealNetwork.h"
+
+
+UTestComponent::UTestComponent()
+{
+	PrimaryComponentTick.bCanEverTick = true;
+	TestProperty = 42.f;
+}
+
+
+void UTestComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	DOREPLIFETIME_CONDITION(UTestComponent, TestProperty, COND_None);
+}
+
+void UTestComponent::OnRep_TestProperty()
+{
+	auto Owner = Cast<ATestStaticComponentReplication>(GetOwner());
+	Owner->Server_ReportReplication(TestProperty);
+}
+
+ATestStaticComponentReplication::ATestStaticComponentReplication()
+{
+	TestName = TEXT("Static component replication");
+	TestComponent = CreateDefaultSubobject<UTestComponent>(TEXT("TestComponent"));
+	check(TestComponent);
+	TestComponent->SetIsReplicated(true);
+}
+
+void ATestStaticComponentReplication::GetLifetimeReplicatedProps(TArray< FLifetimeProperty > & OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+}
+
+bool ATestStaticComponentReplication::Server_ReportReplication_Validate(float RepFloat)
+{
+	return true;
+}
+
+void ATestStaticComponentReplication::Server_ReportReplication_Implementation(float RepFloat)
+{
+	check(RepFloat == TestComponent->TestProperty);
+
+	SignalResponseRecieved();
+}
+
+void ATestStaticComponentReplication::Server_StartTestImpl()
+{
+	TestComponent->TestProperty = FMath::RandRange(-100.f, 100.f);
+
+	SignalReplicationSetup();
+}
+
+void ATestStaticComponentReplication::Server_TearDownImpl()
+{
+}
+
+void ATestStaticComponentReplication::ValidateClientReplicationImpl()
+{
+}
+
+void ATestStaticComponentReplication::SendTestResponseRPCImpl()
+{
+
+}

--- a/Game/Source/TestSuite/Tests/TestStaticComponentReplication.cpp
+++ b/Game/Source/TestSuite/Tests/TestStaticComponentReplication.cpp
@@ -4,13 +4,11 @@
 #include "GameFramework/GameModeBase.h"
 #include "UnrealNetwork.h"
 
-
 UTestComponent::UTestComponent()
 {
 	PrimaryComponentTick.bCanEverTick = true;
 	TestProperty = 42.f;
 }
-
 
 void UTestComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
@@ -21,6 +19,7 @@ void UTestComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLi
 void UTestComponent::OnRep_TestProperty()
 {
 	auto Owner = Cast<ATestStaticComponentReplication>(GetOwner());
+	check(Owner);
 	Owner->Server_ReportReplication(TestProperty);
 }
 
@@ -66,5 +65,6 @@ void ATestStaticComponentReplication::ValidateClientReplicationImpl()
 
 void ATestStaticComponentReplication::SendTestResponseRPCImpl()
 {
-
+	// ILB - Send test response on UTestComponent::OnRep_TestProperty instead so we're certain the TestProperty
+	// has been replicated by that point.
 }

--- a/Game/Source/TestSuite/Tests/TestStaticComponentReplication.h
+++ b/Game/Source/TestSuite/Tests/TestStaticComponentReplication.h
@@ -37,8 +37,6 @@ public:
 	UFUNCTION(Server, Reliable, WithValidation)
 	void Server_ReportReplication(float RepFloat);
 
-	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
-
 	UFUNCTION()
 	virtual void Server_StartTestImpl() override;
 

--- a/Game/Source/TestSuite/Tests/TestStaticComponentReplication.h
+++ b/Game/Source/TestSuite/Tests/TestStaticComponentReplication.h
@@ -1,0 +1,58 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "ReplicationTestCase.h"
+#include "Components/ActorComponent.h"
+#include "TestStaticComponentReplication.generated.h"
+
+UCLASS()
+class TESTSUITE_API UTestComponent : public UActorComponent
+{
+	GENERATED_BODY()
+public:
+
+	UTestComponent();
+
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+	UFUNCTION()
+	void OnRep_TestProperty();
+
+
+	UPROPERTY(ReplicatedUsing = OnRep_TestProperty)
+	float TestProperty;
+};
+
+UCLASS()
+class TESTSUITE_API ATestStaticComponentReplication : public AReplicationTestCase
+{
+	GENERATED_BODY()
+public:	
+
+	ATestStaticComponentReplication();
+
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_ReportReplication(float RepFloat);
+
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+	UFUNCTION()
+	virtual void Server_StartTestImpl() override;
+
+	UFUNCTION()
+	virtual void Server_TearDownImpl() override;
+
+	UFUNCTION()
+	virtual void ValidateClientReplicationImpl() override;
+
+	UFUNCTION()
+	virtual void SendTestResponseRPCImpl() override;
+
+private:
+
+	UPROPERTY()
+	UTestComponent* TestComponent;
+};

--- a/spatial/schema/improbable/unreal/generated/UnrealTestComponent.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealTestComponent.schema
@@ -1,0 +1,28 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+package improbable.unreal.generated.testcomponent;
+
+import "improbable/unreal/gdk/core_types.schema";
+
+component TestComponentSingleClientRepData {
+	id = 100136;
+}
+component TestComponentMultiClientRepData {
+	id = 100137;
+	bool field_breplicates0 = 1; // COND_None // ::ActorComponent
+	bool field_bisactive0 = 2; // COND_None // ::ActorComponent
+	float field_testproperty0 = 3; // COND_None // ::TestComponent
+}
+component TestComponentHandoverData {
+	id = 100138;
+}
+
+component TestComponentClientRPCs {
+	id = 100139;
+}
+component TestComponentServerRPCs {
+	id = 100140;
+}
+component TestComponentNetMulticastRPCs {
+	id = 100141;
+}

--- a/spatial/schema/improbable/unreal/generated/UnrealTestComponent.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealTestComponent.schema
@@ -5,24 +5,24 @@ package improbable.unreal.generated.testcomponent;
 import "improbable/unreal/gdk/core_types.schema";
 
 component TestComponentSingleClientRepData {
-	id = 100136;
+	id = 100142;
 }
 component TestComponentMultiClientRepData {
-	id = 100137;
+	id = 100143;
 	bool field_breplicates0 = 1; // COND_None // ::ActorComponent
 	bool field_bisactive0 = 2; // COND_None // ::ActorComponent
 	float field_testproperty0 = 3; // COND_None // ::TestComponent
 }
 component TestComponentHandoverData {
-	id = 100138;
+	id = 100144;
 }
 
 component TestComponentClientRPCs {
-	id = 100139;
+	id = 100145;
 }
 component TestComponentServerRPCs {
-	id = 100140;
+	id = 100146;
 }
 component TestComponentNetMulticastRPCs {
-	id = 100141;
+	id = 100147;
 }

--- a/spatial/schema/improbable/unreal/generated/UnrealTestStaticComponentReplication.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealTestStaticComponentReplication.schema
@@ -1,0 +1,43 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+package improbable.unreal.generated.teststaticcomponentreplication;
+
+import "improbable/unreal/gdk/core_types.schema";
+
+component TestStaticComponentReplicationSingleClientRepData {
+	id = 100130;
+}
+component TestStaticComponentReplicationMultiClientRepData {
+	id = 100131;
+	bool field_bhidden0 = 1; // COND_None // ::Actor
+	bool field_breplicatemovement0 = 2; // COND_None // ::Actor
+	bool field_btearoff0 = 3; // COND_None // ::Actor
+	bool field_bcanbedamaged0 = 4; // COND_None // ::Actor
+	uint32 field_remoterole0 = 5; // COND_None // ::Actor
+	bytes field_replicatedmovement0 = 6; // COND_SimulatedOrPhysics // ::Actor
+	UnrealObjectRef field_attachmentreplication0_attachparent0 = 7; // COND_Custom // RepAttachment::AttachmentReplication::Actor
+	bytes field_attachmentreplication0_locationoffset0 = 8; // COND_Custom // RepAttachment::AttachmentReplication::Actor
+	bytes field_attachmentreplication0_relativescale3d0 = 9; // COND_Custom // RepAttachment::AttachmentReplication::Actor
+	bytes field_attachmentreplication0_rotationoffset0 = 10; // COND_Custom // RepAttachment::AttachmentReplication::Actor
+	string field_attachmentreplication0_attachsocket0 = 11; // COND_Custom // RepAttachment::AttachmentReplication::Actor
+	UnrealObjectRef field_attachmentreplication0_attachcomponent0 = 12; // COND_Custom // RepAttachment::AttachmentReplication::Actor
+	UnrealObjectRef field_owner0 = 13; // COND_None // ::Actor
+	uint32 field_role0 = 14; // COND_None // ::Actor
+	UnrealObjectRef field_instigator0 = 15; // COND_None // ::Actor
+	int32 field_testbookend0 = 16; // COND_None // ::ReplicationTestCase
+}
+component TestStaticComponentReplicationHandoverData {
+	id = 100132;
+}
+import "improbable/unreal/generated/UnrealTestStaticComponentReplicationTypes.schema";
+
+component TestStaticComponentReplicationClientRPCs {
+	id = 100133;
+}
+component TestStaticComponentReplicationServerRPCs {
+	id = 100134;
+	command UnrealRPCCommandResponse serverreportreplication(teststaticcomponentreplication.ServerReportReplicationRequest);
+}
+component TestStaticComponentReplicationNetMulticastRPCs {
+	id = 100135;
+}

--- a/spatial/schema/improbable/unreal/generated/UnrealTestStaticComponentReplication.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealTestStaticComponentReplication.schema
@@ -5,10 +5,10 @@ package improbable.unreal.generated.teststaticcomponentreplication;
 import "improbable/unreal/gdk/core_types.schema";
 
 component TestStaticComponentReplicationSingleClientRepData {
-	id = 100130;
+	id = 100136;
 }
 component TestStaticComponentReplicationMultiClientRepData {
-	id = 100131;
+	id = 100137;
 	bool field_bhidden0 = 1; // COND_None // ::Actor
 	bool field_breplicatemovement0 = 2; // COND_None // ::Actor
 	bool field_btearoff0 = 3; // COND_None // ::Actor
@@ -27,17 +27,17 @@ component TestStaticComponentReplicationMultiClientRepData {
 	int32 field_testbookend0 = 16; // COND_None // ::ReplicationTestCase
 }
 component TestStaticComponentReplicationHandoverData {
-	id = 100132;
+	id = 100138;
 }
 import "improbable/unreal/generated/UnrealTestStaticComponentReplicationTypes.schema";
 
 component TestStaticComponentReplicationClientRPCs {
-	id = 100133;
+	id = 100139;
 }
 component TestStaticComponentReplicationServerRPCs {
-	id = 100134;
+	id = 100140;
 	command UnrealRPCCommandResponse serverreportreplication(teststaticcomponentreplication.ServerReportReplicationRequest);
 }
 component TestStaticComponentReplicationNetMulticastRPCs {
-	id = 100135;
+	id = 100141;
 }

--- a/spatial/schema/improbable/unreal/generated/UnrealTestStaticComponentReplicationTypes.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealTestStaticComponentReplicationTypes.schema
@@ -1,0 +1,10 @@
+// Copyright (c) Improbable Worlds Ltd, All Rights Reserved
+// Note that this file has been generated automatically
+package improbable.unreal.generated.teststaticcomponentreplication;
+
+import "improbable/unreal/gdk/core_types.schema";
+
+type ServerReportReplicationRequest {
+	uint32 target_subobject_offset = 1;
+	float field_repfloat0 = 2;
+}


### PR DESCRIPTION
Added subobject test to testing framework (activated on 'k'). It currently tests a simple POD replication within an actor component. Getting in now before Ollie starts his tests.

Primary reviewers:
@danielimprobable 