### PR TITLE
Remove reset hack for vehicles

### DIFF
--- a/Game/Source/TestSuite/VehicleCppPawn.cpp
+++ b/Game/Source/TestSuite/VehicleCppPawn.cpp
@@ -112,8 +112,6 @@ AVehicleCppPawn::AVehicleCppPawn()
 	GearDisplayColor = FColor(255, 255, 255, 255);
 
 	bInReverseGear = false;
-
-	bHasReset = false;
 }
 
 void AVehicleCppPawn::SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent)
@@ -184,11 +182,6 @@ void AVehicleCppPawn::EnableIncarView(const bool bState, const bool bForce)
 void AVehicleCppPawn::Tick(float Delta)
 {
 	Super::Tick(Delta);
-
-	if (!bHasReset) {
-		ReregisterAllComponents();
-		bHasReset = true;
-	}
 
 	// Setup the flag to say we are in reverse gear
 	bInReverseGear = GetVehicleMovement()->GetCurrentGear() < 0;

--- a/Game/Source/TestSuite/VehicleCppPawn.h
+++ b/Game/Source/TestSuite/VehicleCppPawn.h
@@ -100,8 +100,6 @@ public:
 	static const FName LookUpBinding;
 	static const FName LookRightBinding;
 
-	bool bHasReset;
-
 private:
 	/** 
 	 * Activate In-Car camera. Enable camera and sets visibility of incar hud display


### PR DESCRIPTION
Removes the reset hack for vehicles, as it is not needed anymore (as far as I can tell).
A side effect of this hack is that vehicles lose velocity on migration - this fixes the issue.