### PR TITLE
Update typebindings (UNR-521 & UNR-522)

### DIFF
--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_GDKTestRunner.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_GDKTestRunner.cpp
@@ -283,18 +283,50 @@ void USpatialTypeBinding_GDKTestRunner::ReceiveAddComponent(USpatialActorChannel
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_GDKTestRunner::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_GDKTestRunner::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::gdktestrunner::GDKTestRunnerSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::gdktestrunner::GDKTestRunnerSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::gdktestrunner::GDKTestRunnerHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_GDKTestRunner::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::gdktestrunner::GDKTestRunnerClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_GDKTestRunner::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_GDKTestRunner.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_GDKTestRunner.h
@@ -9,6 +9,10 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealGDKTestRunner.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
+#include "Tests/GDKTestCase.h"
 #include "Tests/GDKTestRunner.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_NoReferenceBPActor_C.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_NoReferenceBPActor_C.cpp
@@ -274,18 +274,50 @@ void USpatialTypeBinding_NoReferenceBPActor_C::ReceiveAddComponent(USpatialActor
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_NoReferenceBPActor_C::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_NoReferenceBPActor_C::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::noreferencebpactorc::NoReferenceBPActorCSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::noreferencebpactorc::NoReferenceBPActorCSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::noreferencebpactorc::NoReferenceBPActorCHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_NoReferenceBPActor_C::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::noreferencebpactorc::NoReferenceBPActorCClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_NoReferenceBPActor_C::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_NoReferenceBPActor_C.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_NoReferenceBPActor_C.h
@@ -9,7 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealNoReferenceBPActorC.h>
 
+#include "Components/SceneComponent.h"
 #include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 
 #include "ScopedViewCallbacks.h"
 #include "SpatialTypeBinding.h"
@@ -34,7 +36,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_RepCmdConfusion.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_RepCmdConfusion.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealRepCmdConfusion.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "TestSuiteTestClasses.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_S_TestUnderscoreClassName.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_S_TestUnderscoreClassName.cpp
@@ -282,18 +282,50 @@ void USpatialTypeBinding_S_TestUnderscoreClassName::ReceiveAddComponent(USpatial
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_S_TestUnderscoreClassName::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_S_TestUnderscoreClassName::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::stestunderscoreclassname::STestUnderscoreClassNameSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::stestunderscoreclassname::STestUnderscoreClassNameSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::stestunderscoreclassname::STestUnderscoreClassNameHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_S_TestUnderscoreClassName::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::stestunderscoreclassname::STestUnderscoreClassNameClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_S_TestUnderscoreClassName::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_S_TestUnderscoreClassName.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_S_TestUnderscoreClassName.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealSTestUnderscoreClassName.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "TestSuiteTestClasses.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestActor.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestActor.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestActor.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/ReplicationTestHelperClasses.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestBoolReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestBoolReplication.cpp
@@ -280,18 +280,50 @@ void USpatialTypeBinding_TestBoolReplication::ReceiveAddComponent(USpatialActorC
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestBoolReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestBoolReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testboolreplication::TestBoolReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testboolreplication::TestBoolReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testboolreplication::TestBoolReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestBoolReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testboolreplication::TestBoolReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestBoolReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestBoolReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestBoolReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestBoolReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestBoolReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCArrayReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCArrayReplication.cpp
@@ -293,18 +293,50 @@ void USpatialTypeBinding_TestCArrayReplication::ReceiveAddComponent(USpatialActo
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestCArrayReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestCArrayReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testcarrayreplication::TestCArrayReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testcarrayreplication::TestCArrayReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testcarrayreplication::TestCArrayReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestCArrayReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testcarrayreplication::TestCArrayReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestCArrayReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCArrayReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCArrayReplication.h
@@ -9,6 +9,10 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestCArrayReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
+#include "Tests/ReplicationTestHelperClasses.h"
 #include "Tests/TestCArrayReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCharReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCharReplication.cpp
@@ -279,18 +279,50 @@ void USpatialTypeBinding_TestCharReplication::ReceiveAddComponent(USpatialActorC
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestCharReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestCharReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testcharreplication::TestCharReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testcharreplication::TestCharReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testcharreplication::TestCharReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestCharReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testcharreplication::TestCharReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestCharReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCharReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestCharReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestCharReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestCharReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.cpp
@@ -263,18 +263,50 @@ void USpatialTypeBinding_TestComponent::ReceiveAddComponent(USpatialActorChannel
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestComponent::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestComponent::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testcomponent::TestComponentSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testcomponent::TestComponentHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestComponent::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testcomponent::TestComponentClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestComponent::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestComponent.h
@@ -34,7 +34,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestEnumReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestEnumReplication.cpp
@@ -284,18 +284,50 @@ void USpatialTypeBinding_TestEnumReplication::ReceiveAddComponent(USpatialActorC
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestEnumReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestEnumReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testenumreplication::TestEnumReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testenumreplication::TestEnumReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testenumreplication::TestEnumReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestEnumReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testenumreplication::TestEnumReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestEnumReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestEnumReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestEnumReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestEnumReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestEnumReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFNameReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFNameReplication.cpp
@@ -280,18 +280,50 @@ void USpatialTypeBinding_TestFNameReplication::ReceiveAddComponent(USpatialActor
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFNameReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFNameReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testfnamereplication::TestFNameReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testfnamereplication::TestFNameReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testfnamereplication::TestFNameReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestFNameReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testfnamereplication::TestFNameReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestFNameReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFNameReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFNameReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestFNameReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestFNameReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFStringReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFStringReplication.cpp
@@ -280,18 +280,50 @@ void USpatialTypeBinding_TestFStringReplication::ReceiveAddComponent(USpatialAct
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFStringReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFStringReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testfstringreplication::TestFStringReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testfstringreplication::TestFStringReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testfstringreplication::TestFStringReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestFStringReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testfstringreplication::TestFStringReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestFStringReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFStringReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFStringReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestFStringReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestFStringReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFTextReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFTextReplication.cpp
@@ -280,18 +280,50 @@ void USpatialTypeBinding_TestFTextReplication::ReceiveAddComponent(USpatialActor
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFTextReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFTextReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testftextreplication::TestFTextReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testftextreplication::TestFTextReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testftextreplication::TestFTextReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestFTextReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testftextreplication::TestFTextReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestFTextReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFTextReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFTextReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestFTextReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestFTextReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFloatReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFloatReplication.cpp
@@ -281,18 +281,50 @@ void USpatialTypeBinding_TestFloatReplication::ReceiveAddComponent(USpatialActor
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFloatReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestFloatReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testfloatreplication::TestFloatReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testfloatreplication::TestFloatReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testfloatreplication::TestFloatReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestFloatReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testfloatreplication::TestFloatReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestFloatReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFloatReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestFloatReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestFloatReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestFloatReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestIntReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestIntReplication.cpp
@@ -287,18 +287,50 @@ void USpatialTypeBinding_TestIntReplication::ReceiveAddComponent(USpatialActorCh
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestIntReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestIntReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testintreplication::TestIntReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testintreplication::TestIntReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testintreplication::TestIntReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestIntReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testintreplication::TestIntReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestIntReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestIntReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestIntReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestIntReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestIntReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestMulticastRPC.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestMulticastRPC.cpp
@@ -279,18 +279,50 @@ void USpatialTypeBinding_TestMulticastRPC::ReceiveAddComponent(USpatialActorChan
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestMulticastRPC::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestMulticastRPC::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testmulticastrpc::TestMulticastRPCSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testmulticastrpc::TestMulticastRPCSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testmulticastrpc::TestMulticastRPCHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestMulticastRPC::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testmulticastrpc::TestMulticastRPCClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestMulticastRPC::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestMulticastRPC.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestMulticastRPC.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestMulticastRPC.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestMulticastRPC.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.cpp
@@ -311,18 +311,50 @@ void USpatialTypeBinding_TestStaticComponentReplication::ReceiveAddComponent(USp
 	TestComponentTypeBinding->ReceiveAddComponent(Channel, AddComponentOp);
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestStaticComponentReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestStaticComponentReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestStaticComponentReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::teststaticcomponentreplication::TestStaticComponentReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestStaticComponentReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestStaticComponentReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestStaticComponentReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/TestStaticComponentReplication.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteCharacter.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteCharacter.h
@@ -9,7 +9,14 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestSuiteCharacter.h>
 
+#include "Animation/AnimMontage.h"
 #include "Components/PrimitiveComponent.h"
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Controller.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/PlayerState.h"
+#include "Tests/GDKTestRunner.h"
 #include "TestSuiteCharacter.h"
 
 #include "ScopedViewCallbacks.h"
@@ -35,7 +42,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameMode.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameMode.cpp
@@ -273,18 +273,50 @@ void USpatialTypeBinding_TestSuiteGameMode::ReceiveAddComponent(USpatialActorCha
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestSuiteGameMode::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestSuiteGameMode::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testsuitegamemode::TestSuiteGameModeSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testsuitegamemode::TestSuiteGameModeSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testsuitegamemode::TestSuiteGameModeHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestSuiteGameMode::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testsuitegamemode::TestSuiteGameModeClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestSuiteGameMode::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameMode.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameMode.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestSuiteGameMode.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "TestSuiteGameMode.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameStateBase.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameStateBase.cpp
@@ -277,18 +277,50 @@ void USpatialTypeBinding_TestSuiteGameStateBase::ReceiveAddComponent(USpatialAct
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestSuiteGameStateBase::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestSuiteGameStateBase::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testsuitegamestatebase::TestSuiteGameStateBaseSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testsuitegamestatebase::TestSuiteGameStateBaseSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testsuitegamestatebase::TestSuiteGameStateBaseHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestSuiteGameStateBase::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testsuitegamestatebase::TestSuiteGameStateBaseClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestSuiteGameStateBase::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameStateBase.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuiteGameStateBase.h
@@ -9,6 +9,11 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestSuiteGameStateBase.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/SpectatorPawn.h"
 #include "TestSuiteGameStateBase.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +39,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuitePlayerController.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuitePlayerController.h
@@ -11,6 +11,7 @@
 
 #include "Camera/CameraAnim.h"
 #include "Camera/CameraShake.h"
+#include "Components/SceneComponent.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/ForceFeedbackEffect.h"
 #include "GameFramework/HUD.h"
@@ -46,7 +47,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuitePlayerState.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuitePlayerState.cpp
@@ -284,18 +284,50 @@ void USpatialTypeBinding_TestSuitePlayerState::ReceiveAddComponent(USpatialActor
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestSuitePlayerState::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestSuitePlayerState::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testsuiteplayerstate::TestSuitePlayerStateSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testsuiteplayerstate::TestSuitePlayerStateSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testsuiteplayerstate::TestSuitePlayerStateHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestSuitePlayerState::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testsuiteplayerstate::TestSuitePlayerStateClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestSuitePlayerState::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuitePlayerState.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestSuitePlayerState.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestSuitePlayerState.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "TestSuitePlayerState.h"
 
 #include "ScopedViewCallbacks.h"
@@ -34,7 +37,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestTArrayReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestTArrayReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestTArrayReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/ReplicationTestHelperClasses.h"
 #include "Tests/TestTArrayReplication.h"
 
@@ -35,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUObjectReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUObjectReplication.cpp
@@ -282,18 +282,50 @@ void USpatialTypeBinding_TestUObjectReplication::ReceiveAddComponent(USpatialAct
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestUObjectReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestUObjectReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testuobjectreplication::TestUObjectReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testuobjectreplication::TestUObjectReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testuobjectreplication::TestUObjectReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestUObjectReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testuobjectreplication::TestUObjectReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestUObjectReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUObjectReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUObjectReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestUObjectReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/ReplicationTestHelperClasses.h"
 #include "Tests/TestUObjectReplication.h"
 
@@ -35,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUStructReplication.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUStructReplication.cpp
@@ -290,18 +290,50 @@ void USpatialTypeBinding_TestUStructReplication::ReceiveAddComponent(USpatialAct
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestUStructReplication::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_TestUStructReplication::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testustructreplication::TestUStructReplicationSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testustructreplication::TestUStructReplicationSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testustructreplication::TestUStructReplicationHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_TestUStructReplication::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testustructreplication::TestUStructReplicationClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_TestUStructReplication::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUStructReplication.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_TestUStructReplication.h
@@ -9,6 +9,9 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestUStructReplication.h>
 
+#include "Components/SceneComponent.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "Tests/ReplicationTestHelperClasses.h"
 #include "Tests/TestUStructReplication.h"
 
@@ -35,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_Testcase_Properties_C.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_Testcase_Properties_C.h
@@ -9,8 +9,10 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestcasePropertiesC.h>
 
+#include "Components/SceneComponent.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Character.h"
+#include "GameFramework/Pawn.h"
 #include "TestSuiteCharacter.h"
 
 #include "ScopedViewCallbacks.h"
@@ -36,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_Testcase_RPCs_C.cpp
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_Testcase_RPCs_C.cpp
@@ -280,18 +280,50 @@ void USpatialTypeBinding_Testcase_RPCs_C::ReceiveAddComponent(USpatialActorChann
 	}
 }
 
-worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_Testcase_RPCs_C::GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const
+worker::Map<worker::ComponentId, worker::InterestOverride> USpatialTypeBinding_Testcase_RPCs_C::GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const
 {
 	worker::Map<worker::ComponentId, worker::InterestOverride> Interest;
 	if (bIsClient)
 	{
-		if (!bAutonomousProxy)
-		{
-			Interest.emplace(improbable::unreal::generated::testcaserpcsc::TestcaseRPCsCSingleClientRepData::ComponentId, worker::InterestOverride{false});
-		}
+		Interest.emplace(improbable::unreal::generated::testcaserpcsc::TestcaseRPCsCSingleClientRepData::ComponentId, worker::InterestOverride{bNetOwned});
 		Interest.emplace(improbable::unreal::generated::testcaserpcsc::TestcaseRPCsCHandoverData::ComponentId, worker::InterestOverride{false});
 	}
 	return Interest;
+}
+
+bool USpatialTypeBinding_Testcase_RPCs_C::UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const
+{
+	TSharedPtr<worker::Connection> PinnedConnection = Interop->GetSpatialOS()->GetConnection().Pin();
+	TSharedPtr<worker::View> PinnedView = Interop->GetSpatialOS()->GetView().Pin();
+	worker::EntityId Id = Channel->GetEntityId().ToSpatialEntityId();
+
+	if (PinnedConnection.IsValid() && PinnedView.IsValid())
+	{
+		worker::Option<improbable::EntityAcl::Data &> Data = PinnedView->Entities[Id].Get<improbable::EntityAcl>();
+		if (Data.empty())
+		{
+			return false;
+		}
+		worker::Map<uint32_t, improbable::WorkerRequirementSet> WriteACL = Data->component_write_acl();
+
+		std::string PlayerWorkerId;
+		if (bNetOwned)
+		{
+			PlayerWorkerId = TCHAR_TO_UTF8(*Channel->Connection->PlayerController->PlayerState->UniqueId.ToString());
+		}
+
+		improbable::WorkerAttributeSet OwningClientAttribute{ { "workerId:" + PlayerWorkerId } };
+		improbable::WorkerRequirementSet OwningClientOnly{ { OwningClientAttribute } };
+
+		WriteACL[improbable::unreal::generated::testcaserpcsc::TestcaseRPCsCClientRPCs::ComponentId] = OwningClientOnly;
+
+		improbable::EntityAcl::Update Update;
+		Update.set_component_write_acl(WriteACL);
+		PinnedConnection->SendComponentUpdate<improbable::EntityAcl>(Id, Update);
+		return true;
+	}
+
+	return false;
 }
 
 void USpatialTypeBinding_Testcase_RPCs_C::BuildSpatialComponentUpdate(

--- a/Game/Source/TestSuite/Generated/SpatialTypeBinding_Testcase_RPCs_C.h
+++ b/Game/Source/TestSuite/Generated/SpatialTypeBinding_Testcase_RPCs_C.h
@@ -9,8 +9,10 @@
 #include <improbable/unreal/gdk/unreal_metadata.h>
 #include <improbable/unreal/generated/UnrealTestcaseRPCsC.h>
 
+#include "Components/SceneComponent.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Character.h"
+#include "GameFramework/Pawn.h"
 #include "TestSuiteCharacter.h"
 
 #include "ScopedViewCallbacks.h"
@@ -36,7 +38,8 @@ public:
 	void SendRPCCommand(UObject* TargetObject, const UFunction* const Function, void* Parameters) override;
 
 	void ReceiveAddComponent(USpatialActorChannel* Channel, UAddComponentOpWrapperBase* AddComponentOp) const override;
-	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bAutonomousProxy) const override;
+	worker::Map<worker::ComponentId, worker::InterestOverride> GetInterestOverrideMap(bool bIsClient, bool bNetOwned) const override;
+	bool UpdateEntityACL(USpatialActorChannel* Channel, bool bNetOwned) const override;
 
 	void BuildSpatialComponentUpdate(
 		const FPropertyChangeState& Changes,

--- a/spatial/schema/improbable/unreal/generated/UnrealNoReferenceBPActorC.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealNoReferenceBPActorC.schema
@@ -5,10 +5,10 @@ package improbable.unreal.generated.noreferencebpactorc;
 import "improbable/unreal/gdk/core_types.schema";
 
 component NoReferenceBPActorCSingleClientRepData {
-	id = 100185;
+	id = 100199;
 }
 component NoReferenceBPActorCMultiClientRepData {
-	id = 100186;
+	id = 100200;
 	bool field_bhidden0 = 1; // COND_None // ::Actor
 	bool field_breplicatemovement0 = 2; // COND_None // ::Actor
 	bool field_btearoff0 = 3; // COND_None // ::Actor
@@ -27,18 +27,18 @@ component NoReferenceBPActorCMultiClientRepData {
 	bool field_mytestvariable0 = 16; // COND_None // ::NoReferenceBPActor_C
 }
 component NoReferenceBPActorCHandoverData {
-	id = 100187;
+	id = 100201;
 }
 
 component NoReferenceBPActorCClientRPCs {
-	id = 100188;
+	id = 100202;
 }
 component NoReferenceBPActorCServerRPCs {
-	id = 100189;
+	id = 100203;
 }
 component NoReferenceBPActorCCrossServerRPCs {
-	id = 100190;
+	id = 100204;
 }
 component NoReferenceBPActorCNetMulticastRPCs {
-	id = 100191;
+	id = 100205;
 }

--- a/spatial/schema/improbable/unreal/generated/UnrealTestcasePropertiesC.schema
+++ b/spatial/schema/improbable/unreal/generated/UnrealTestcasePropertiesC.schema
@@ -5,10 +5,10 @@ package improbable.unreal.generated.testcasepropertiesc;
 import "improbable/unreal/gdk/core_types.schema";
 
 component TestcasePropertiesCSingleClientRepData {
-	id = 100178;
+	id = 100185;
 }
 component TestcasePropertiesCMultiClientRepData {
-	id = 100179;
+	id = 100186;
 	bool field_bhidden0 = 1; // COND_None // ::Actor
 	bool field_breplicatemovement0 = 2; // COND_None // ::Actor
 	bool field_btearoff0 = 3; // COND_None // ::Actor
@@ -33,18 +33,18 @@ component TestcasePropertiesCMultiClientRepData {
 	list<bytes> field_testbpstructarray0 = 22; // COND_None // ::Testcase_Properties_C
 }
 component TestcasePropertiesCHandoverData {
-	id = 100180;
+	id = 100187;
 }
 
 component TestcasePropertiesCClientRPCs {
-	id = 100181;
+	id = 100188;
 }
 component TestcasePropertiesCServerRPCs {
-	id = 100182;
+	id = 100189;
 }
 component TestcasePropertiesCCrossServerRPCs {
-	id = 100183;
+	id = 100190;
 }
 component TestcasePropertiesCNetMulticastRPCs {
-	id = 100184;
+	id = 100191;
 }


### PR DESCRIPTION
Updates typebindings to include changes made by UNR-521 & UNR-522 to fix dynamic ownership issues. Also a drive-by modification due to updated includes.