### PR TITLE
No need to pass game name in worker config

### DIFF
--- a/spatial/workers/unreal/spatialos.UnrealWorker.worker.json
+++ b/spatial/workers/unreal/spatialos.UnrealWorker.worker.json
@@ -88,7 +88,6 @@
       "command": "StartWorker.sh",
       "arguments": [
         "${IMPROBABLE_WORKER_ID}",
-        "TestSuite",
         "ThirdPersonExampleMap",
         "+appName",
         "${IMPROBABLE_PROJECT_NAME}",


### PR DESCRIPTION
`UnrealGDK` PR: https://github.com/spatialos/UnrealGDK/pull/536