### PR TITLE
Removed redundant InitPlayerState from player controller

### DIFF
--- a/Game/Source/TestSuite/TestSuitePlayerController.cpp
+++ b/Game/Source/TestSuite/TestSuitePlayerController.cpp
@@ -24,23 +24,3 @@ bool ATestSuitePlayerController::TestMulticast_Validate()
 void ATestSuitePlayerController::TestMulticast_Implementation()
 {
 }
-
-void ATestSuitePlayerController::InitPlayerState()
-{
-	// TODO: this is a workaround until we can query a replicated UObject*'s UnrealObjRef - UNR-407
-	UWorld* World = GetWorld();
-	check(World);
-	USpatialNetDriver* NetDriver = Cast<USpatialNetDriver>(World->GetNetDriver());
-	if (NetDriver)
-	{
-		const Worker_EntityId EntityId = NetDriver->GetEntityRegistry()->GetEntityIdFromActor(this);
-		UE_LOG(LogTemp, Log, TEXT("PC:InitPlayerState called with entity id %d"), EntityId);
-		if (EntityId != 0)
-		{
-			// EntityId is not 0, which means that this PC has already been initialized.
-			return;
-		}
-	}
-
-	Super::InitPlayerState();
-}

--- a/Game/Source/TestSuite/TestSuitePlayerController.h
+++ b/Game/Source/TestSuite/TestSuitePlayerController.h
@@ -19,8 +19,4 @@ class TESTSUITE_API ATestSuitePlayerController : public APlayerController
 
 	UFUNCTION(NetMulticast, Unreliable, WithValidation)
 	void TestMulticast();
-
-public:
-
-	virtual void InitPlayerState() override;
 };


### PR DESCRIPTION
ATestSuitePlayerController::InitPlayerState functionality has been moved to the engine so is no longer required in each project.

See - https://github.com/improbableio/UnrealEngine/blob/4.20-SpatialOSUnrealGDK/Engine/Source/Runtime/Engine/Private/Controller.cpp

Primary Reviewers:
@improbable-valentyn @jnicholas-io